### PR TITLE
toString needed for ProxyMockFunction

### DIFF
--- a/core/src/main/scala/org/scalamock/ProxyMockFunction.scala
+++ b/core/src/main/scala/org/scalamock/ProxyMockFunction.scala
@@ -21,6 +21,7 @@
 package org.scalamock
 
 private[scalamock] class ProxyMockFunction(factory: MockFactoryBase, name: Symbol) extends MockFunction(factory, name) {
+  override def toString = name.name.toString
   
   def apply(args: Array[AnyRef]) = handle(if (args != null) args.map(_.asInstanceOf[Any]) else Array[Any]())
 

--- a/core_tests/src/test/scala/org/scalamock/MockFunctionTest.scala
+++ b/core_tests/src/test/scala/org/scalamock/MockFunctionTest.scala
@@ -310,6 +310,11 @@ class MockFunctionTest extends WordSpec with MockFactory {
       expect("a helpful name") { m.toString }
     }
 
+    "have the name we gave a ProxyMockFunction" in {
+      val m = new ProxyMockFunction(this, Symbol("a helpful name"))
+      expect("a helpful name") { m.toString }
+    }
+
     "match a simple predicate" in {
       val m = mockFunction[Int, Double, String]
       


### PR DESCRIPTION
## Situation

When using Proxy mocking, expectation failures in Borachio used to show expectation failures as a list of "Expectations" and "Actual calls" with method/function **names**.
When doing this in ScalaMock, it shows as raw `Object.toString` output, e.g: `org.scalamock.ProxyMockFunction@73a34b`
## Investigation

Checking, I found `MockFunction` has `toString` and a test but `ProxyMockFunction` does not and is not test-covered.
## Fix

For starters, I've added a fix and a test to the existing `MockFunctionTest.scala`.  I guess the ideal fix includes creating a `ProxyMockFunctionTest.scala` with this and all other tests from `MockFunctionTest.scala` (to ensure it is entirely predictable -- especially takes no regressions).  Ok, _ideal_ fix probably includes refactoring all common test code out of both ;-)

Hope this helps,
Rupert.

p.s. This is my first GitHub pull request so please feel free to offer advice / correct if I've done things wrong (e.g. I only noticed the advice about offering on branches _after_ I pushed!  Guess that would have been better?)
