### PR TITLE
Widen MockFactoryBase.ExpectationException to Throwable

### DIFF
--- a/core/src/main/scala/org/scalamock/MockFactoryBase.scala
+++ b/core/src/main/scala/org/scalamock/MockFactoryBase.scala
@@ -22,7 +22,7 @@ package org.scalamock
 trait MockFactoryBase extends Mock {
   import language.implicitConversions
   
-  type ExpectationException <: Exception
+  type ExpectationException <: Throwable
   
   protected def withExpectations[T](what: => T): T = {
     resetExpectations


### PR DESCRIPTION
This lower bound is too restrictive, it prevents for instance the use of AssertionError (if you want to integration with JUnit).
