### PR TITLE
Add support for org.scalatest.path.FunSpec and org.scalatest.path.FreeSpec

### DIFF
--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/package.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/package.scala
@@ -1,0 +1,16 @@
+package org.scalamock
+
+import org.scalatest.exceptions.StackDepthException
+
+/**
+ * Created: 4/15/15
+ */
+package object scalatest {
+  private[scalatest] def failedCodeStackDepthFn(methodName: Option[Symbol]): StackDepthException => Int = e => {
+    e.getStackTrace indexWhere { s =>
+      !s.getClassName.startsWith("org.scalamock") && !s.getClassName.startsWith("org.scalatest") &&
+          !(s.getMethodName == "newExpectationException") && !(s.getMethodName == "reportUnexpectedCall") &&
+          !(methodName.isDefined && s.getMethodName == methodName.get.name)
+    }
+  }
+}

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
@@ -1,0 +1,26 @@
+package org.scalamock.test.scalatest
+
+import org.scalamock.scalatest.PathMockFactory
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.{Matchers, path}
+
+
+/**
+ * Created: 4/15/15
+ */
+class PathSpecTest extends path.FunSpec with Matchers with PathMockFactory {
+  describe("PathSpec") {
+    val mockFn = mockFunction[Int, Int]
+    mockFn expects 42
+
+    it("does not throw exception if expectations are met") {
+      mockFn(42)
+
+      verifyExpectations()
+    }
+
+    it("fails if expectation is not met") {
+      an[TestFailedException] should be thrownBy verifyExpectations()
+    }
+  }
+}


### PR DESCRIPTION
The withFixture method is final in path.FreeSpec and path.FunSpec, so MockFactory won't work.  I prefer path.FunSpec because of the way it allows you to structure your test... you can define certain variables in nested suites that are only visible in that suite and you can tear down each suite separately if you need to.

My goal here was to have minimal duplication and not to change any existing hierarchies.