### PR TITLE
Enable mocking a trait which has a final method

### DIFF
--- a/core/src/main/scala/org/scalamock/clazz/MockMaker.scala
+++ b/core/src/main/scala/org/scalamock/clazz/MockMaker.scala
@@ -282,6 +282,7 @@ class MockMaker[C <: Context](val ctx: C) {
     val typeToMock = weakTypeOf[T]
     val anon = TypeName("$anon")
     val methodsToMock = methodsNotInObject.filter { m =>
+      !m.isFinal &&
       !m.isConstructor && !m.isPrivate && m.privateWithin == NoSymbol &&
         !m.asInstanceOf[reflect.internal.HasFlags].hasFlag(reflect.internal.Flags.BRIDGE) &&
         !m.isParamWithDefault && // see issue #43

--- a/core_tests/src/main/scala/com/paulbutcher/test/FinalMethodTrait.scala
+++ b/core_tests/src/main/scala/com/paulbutcher/test/FinalMethodTrait.scala
@@ -1,0 +1,10 @@
+package com.paulbutcher.test
+
+
+trait FinalMethodTrait {
+
+  def somePublicMethod(param: String)
+
+  final def someFinalMethod(param: Int) = "final method"
+
+}

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -397,5 +397,9 @@ class MockTest extends FreeSpec with MockFactory with ShouldMatchers {
       (provider.find[User](_: Int)(_: ClassTag[User])) expects (13, *) returning (Failure[User](new Exception()))
       provider.find[User](13) shouldBe a[Failure[_]]
     }
+
+    "mock a trait which has a final method" in withExpectations {
+      val m = mock[FinalMethodTrait]  //test will not compile if the test fails (cannot override final member)
+    }
   }
 }


### PR DESCRIPTION
I did this because currently, attempting to mock a class or trait which has a final method results in a compilation failure.  I think it's better to say that you simply can't mock the final method itself, but you can still mock other methods.  This pull request just filters final methods out from the methods that the mock attempts to implement.
