### PR TITLE
#56 Mocking class with nonempty default constructor

### DIFF
--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -397,5 +397,11 @@ class MockTest extends FreeSpec with MockFactory with ShouldMatchers {
       (provider.find[User](_: Int)(_: ClassTag[User])) expects (13, *) returning (Failure[User](new Exception()))
       provider.find[User](13) shouldBe a[Failure[_]]
     }
+
+    "mock class with nonempty default constructor" in {
+      class TestNonEmptyDefaultConstructor(a: Int, b: String, c: AnyRef, d: Any)(aa: String)
+
+      val m = mock[TestNonEmptyDefaultConstructor]
+    }
   }
 }


### PR DESCRIPTION
Hi everyone,

I have fixed macro for defining `mock`s and `stub`s so that you can now create mock for classes that have nonempty default constructor. It works now also for multiple arguments lists. ~~It is not perfect because it has some problems with many arguments lists like implicit one. But tree generated by macro is correct. You can compare yourself below:
macro code:~~

``` scala
{
  final class $anon extends TestNonEmptyDefaultConstructor {
    def <init>() = {
      super.<init>(null.asInstanceOf[Int], null.asInstanceOf[String], null.asInstanceOf[AnyRef], null.asInstanceOf[Any], null.asInstanceOf[Int]);
      ()
    };
    val mock$special$mockName = MockTest.this._factory.generateMockDefaultName("mock").name
  };
  new $anon()
}.asInstanceOf[TestNonEmptyDefaultConstructor]
```

~~Scala compiler for similar example~~

``` scala
[[syntax trees at end of                     icode]] // Foo.scala
package <empty> {
  class Foo extends Object {
    def <init>(a: Int, b: String): Foo = {
      Foo.super.<init>();
      ()
    }
  }
}
```

~~Both classes have multiple arguments lists but mock does not compile. Anyway for me it is another improvement.~~ Please make review @paulbutcher
