### PR TITLE
Resolving overloaded method bugfix

### DIFF
--- a/core/src/main/scala/org/scalamock/clazz/MockFunctionFinder.scala
+++ b/core/src/main/scala/org/scalamock/clazz/MockFunctionFinder.scala
@@ -43,6 +43,17 @@ object MockFunctionFinder {
       c.abort(c.enclosingPosition, message)
     }
 
+    def sameTypes(types1: List[Type], types2: List[Type]) = {
+      // see issue #34
+      var these = types1.map(_.dealias)
+      var those = types2.map(_.dealias)
+      while (!these.isEmpty && !those.isEmpty && these.head =:= those.head) {
+        these = these.tail
+        those = those.tail
+      }
+      these.isEmpty && those.isEmpty
+    }
+
     // This performs a ridiculously simple-minded overload resolution, but it works well enough for
     // our purposes, and is much easier than trying to backport the implementation that was deleted
     // from the macro API (c.f. https://groups.google.com/d/msg/scala-internals/R1iZXfotqds/3xytfX39U2wJ)
@@ -56,7 +67,7 @@ object MockFunctionFinder {
           else
             paramTypes(tpe)
         }
-        pts.map(_.dealias) sameElements actuals.map(_.dealias) // see issue #34
+        sameTypes(pts, actuals)
       } getOrElse {
         reportError(s"Unable to resolve overloaded method ${method.name}")
       }

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/OverloadedMethodsTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/OverloadedMethodsTest.scala
@@ -116,4 +116,22 @@ class OverloadedMethodsTest extends IsolatedSpec {
     m.print("foo")
   }
 
+  they should "handle type aliases correctly" in {
+    type X = Int
+    type Y = X
+
+    class GenericType[T]
+    type ConcreteType = GenericType[X]
+
+    class Foo {
+      def foo()(y: GenericType[Y]) = 42
+      def foo(a: Int)(y: GenericType[Y]) = 42
+    }
+
+    val m = mock[Foo]
+    (m.foo()(_: ConcreteType)) expects (*)
+
+    m.foo()(new ConcreteType())
+  }
 }
+


### PR DESCRIPTION
While resolving overloaded methods, the currently used method `sameElements` does a comparison with the `==` operator. This does not work in all cases and, according to [Scala Reflect API Types](http://www.scala-lang.org/api/2.11.5/scala-reflect/index.html#scala.reflect.api.Types), the `=:=` operator should be used to compare types.

The patch contains a test case which fails with the current version and a fix, which compares the argument type list with the recommended `=:=`.
