### PR TITLE
Adding (failing) test for functions curried by returning another func…

### DIFF
--- a/core_tests/src/main/scala/com/paulbutcher/test/TestTrait.scala
+++ b/core_tests/src/main/scala/com/paulbutcher/test/TestTrait.scala
@@ -37,6 +37,7 @@ trait TestTrait {
   def +(x: TestTrait): TestTrait
   
   def curried(x: Int)(y: Double): String
+  def curriedFuncReturn(x: Int): Double => String
   def polymorphic[T](x: List[T]): String
   def polycurried[T1, T2](x: T1)(y: T2): (T1, T2)
   def polymorphicParam(x: (Int, Double)): String

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -85,6 +85,15 @@ class MockTest extends FreeSpec with MockFactory with ShouldMatchers {
         assertResult("curried method called") { partial(1.23) }
       }
     }
+
+    "cope with curried function returning methods" in {
+      withExpectations {
+        val m = mock[TestTrait]
+        (m.curriedFuncReturn(_: Int)(_: Double)).expects(10, 1.23).returning("curried func return method called")
+        val partial = m.curriedFuncReturn(10)
+        assertResult("curried func return method called") { partial(1.23) }
+      }
+    }
     
     "cope with polymorphic methods" in {
       withExpectations {


### PR DESCRIPTION
Pull request corresponding to https://github.com/paulbutcher/ScalaMock/issues/150

This added test case will currently fail in the same way outlined in the above issue

```
[info] Compiling 6 Scala sources to ScalaMock/core_tests/target/scala-2.11/test-classes...
[error] symbol value x$3 does not exist in com.paulbutcher.test.mock.MockTest.<init>
[trace] Stack trace suppressed: run last core_tests/test:compile for the full output.
[error] (core_tests/test:compile) scala.reflect.internal.FatalError: symbol value x$3 does not exist in com.paulbutcher.test.mock.MockTest.<init>
[error] Total time: 14 s, completed Aug 8, 2016 7:48:48 PM
```

And the output from `last core_tests/test:compile`

```
[error] symbol value x$3 does not exist in com.paulbutcher.test.mock.MockTest.<init>
scala.reflect.internal.FatalError: symbol value x$3 does not exist in com.paulbutcher.test.mock.MockTest.<init>
        at scala.reflect.internal.Reporting$class.abort(Reporting.scala:59)
        at scala.reflect.internal.SymbolTable.abort(SymbolTable.scala:16)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.genLoadIdent$1(GenICode.scala:885)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:891)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genLoadArguments$1.apply(GenICode.scala:1133)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genLoadArguments$1.apply(GenICode.scala:1131)
        at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
        at scala.collection.immutable.List.foldLeft(List.scala:84)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.genLoadArguments(GenICode.scala:1131)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.genLoadApply3$1(GenICode.scala:697)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:707)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:924)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:916)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genLoadArguments$1.apply(GenICode.scala:1133)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genLoadArguments$1.apply(GenICode.scala:1131)
        at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
        at scala.collection.immutable.List.foldLeft(List.scala:84)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.genLoadArguments(GenICode.scala:1131)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.genLoadApply6$1(GenICode.scala:778)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:809)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genStat(GenICode.scala:181)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genStat$1.apply(GenICode.scala:155)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase$$anonfun$genStat$1.apply(GenICode.scala:155)
        at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:124)
        at scala.collection.immutable.List.foldLeft(List.scala:84)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.scala$tools$nsc$backend$icode$GenICode$ICodePhase$$genLoad(GenICode.scala:915)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:123)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:71)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:148)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:98)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:71)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:89)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.gen(GenICode.scala:67)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.apply(GenICode.scala:63)
        at scala.tools.nsc.Global$GlobalPhase$$anonfun$applyPhase$1.apply$mcV$sp(Global.scala:441)
        at scala.tools.nsc.Global$GlobalPhase.withCurrentUnit(Global.scala:432)
        at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:441)
        at scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:399)
        at scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:399)
        at scala.collection.Iterator$class.foreach(Iterator.scala:750)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1202)
        at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:399)
        at scala.tools.nsc.backend.icode.GenICode$ICodePhase.run(GenICode.scala:55)
        at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1500)
        at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1487)
        at scala.tools.nsc.Global$Run.compileSources(Global.scala:1482)
        at scala.tools.nsc.Global$Run.compile(Global.scala:1580)
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:116)
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:95)
        at xsbt.CompilerInterface.run(CompilerInterface.scala:26)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sbt.compiler.AnalyzingCompiler.call(AnalyzingCompiler.scala:101)
        at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:47)
        at sbt.compiler.AnalyzingCompiler.compile(AnalyzingCompiler.scala:41)
        at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply$mcV$sp(AggressiveCompile.scala:97)
        at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:97)
        at sbt.compiler.AggressiveCompile$$anonfun$3$$anonfun$compileScala$1$1.apply(AggressiveCompile.scala:97)
        at sbt.compiler.AggressiveCompile.sbt$compiler$AggressiveCompile$$timed(AggressiveCompile.scala:162)
        at sbt.compiler.AggressiveCompile$$anonfun$3.compileScala$1(AggressiveCompile.scala:96)
        at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:139)
        at sbt.compiler.AggressiveCompile$$anonfun$3.apply(AggressiveCompile.scala:86)
        at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:38)
        at sbt.inc.IncrementalCompile$$anonfun$doCompile$1.apply(Compile.scala:36)
        at sbt.inc.IncrementalCommon.cycle(IncrementalCommon.scala:31)
        at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:39)
        at sbt.inc.Incremental$$anonfun$1.apply(Incremental.scala:38)
        at sbt.inc.Incremental$.manageClassfiles(Incremental.scala:66)
        at sbt.inc.Incremental$.compile(Incremental.scala:38)
        at sbt.inc.IncrementalCompile$.apply(Compile.scala:26)
        at sbt.compiler.AggressiveCompile.compile2(AggressiveCompile.scala:153)
        at sbt.compiler.AggressiveCompile.compile1(AggressiveCompile.scala:70)
        at sbt.compiler.AggressiveCompile.apply(AggressiveCompile.scala:45)
        at sbt.Compiler$.apply(Compiler.scala:74)
        at sbt.Compiler$.apply(Compiler.scala:65)
        at sbt.Defaults$.sbt$Defaults$$compileTaskImpl(Defaults.scala:789)
        at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:781)
        at sbt.Defaults$$anonfun$compileTask$1.apply(Defaults.scala:781)
        at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
        at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
        at sbt.std.Transform$$anon$4.work(System.scala:63)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
        at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
        at sbt.Execute.work(Execute.scala:235)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
        at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
        at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
[error] (core_tests/test:compile) scala.reflect.internal.FatalError: symbol value x$3 does not exist in com.paulbutcher.test.mock.MockTest.<init>
```
