### PR TITLE
Update to ScalaTest 3.0.0, sbt 0.13.12, Scala 2.10.6.

### DIFF
--- a/core_tests/src/main/scala/com/paulbutcher/test/IsolatedSpec.scala
+++ b/core_tests/src/main/scala/com/paulbutcher/test/IsolatedSpec.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{ FlatSpec, ShouldMatchers, OneInstancePerTest }
+import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
-class IsolatedSpec extends FlatSpec with MockFactory with ShouldMatchers with OneInstancePerTest {
+class IsolatedSpec extends FlatSpec with MockFactory with Matchers with OneInstancePerTest {
 
   def repeat(n: Int)(what: => Unit) {
     for (i <- 0 until n)

--- a/core_tests/src/test/scala/com/paulbutcher/test/matchers/ArgThatTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/matchers/ArgThatTest.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test.matchers
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{ FlatSpec, ShouldMatchers }
+import org.scalatest.{ FlatSpec, Matchers }
 
-class ArgThatTest extends FlatSpec with ShouldMatchers with MockFactory {
+class ArgThatTest extends FlatSpec with Matchers with MockFactory {
 
   behavior of "ArgThat"
 

--- a/core_tests/src/test/scala/com/paulbutcher/test/matchers/MockParameterTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/matchers/MockParameterTest.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test.matchers
 
 import org.scalamock.matchers.{MatchAny, MatchEpsilon, MockParameter}
-import org.scalatest.{FreeSpec, ShouldMatchers}
+import org.scalatest.{FreeSpec, Matchers}
 
-class MockParameterTest extends FreeSpec with ShouldMatchers {
+class MockParameterTest extends FreeSpec with Matchers {
   
   "A mock parameter should" - {
     "be equal" - {

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -23,14 +23,14 @@ package com.paulbutcher.test.mock
 import com.paulbutcher.test._
 import org.scalamock.function.FunctionAdapter1
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{ShouldMatchers, FreeSpec}
+import org.scalatest.{Matchers, FreeSpec}
 import some.other.pkg._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{ TypeTag, typeTag }
 import scala.util.{Try, Failure}
 
-class MockTest extends FreeSpec with MockFactory with ShouldMatchers {
+class MockTest extends FreeSpec with MockFactory with Matchers {
   
   autoVerify = false
   

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTestManyParams.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTestManyParams.scala
@@ -24,7 +24,7 @@ import com.paulbutcher.test.{ManyParamsClass, ManyParamsTrait}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 
-class MockTestManyParams extends FreeSpec with MockFactory with ShouldMatchers {
+class MockTestManyParams extends FreeSpec with MockFactory with Matchers {
   autoVerify = false
 
   "Mocks should" - {

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AbstractMockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AbstractMockFactory.scala
@@ -21,10 +21,10 @@
 package org.scalamock.scalatest
 
 import org.scalamock.MockFactoryBase
-import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{Failed, Outcome, Suite, SuiteMixin}
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import org.scalatest._
 
-trait AbstractMockFactory extends SuiteMixin with MockFactoryBase { this: Suite =>
+trait AbstractMockFactory extends TestSuiteMixin with MockFactoryBase with TestSuite {
   
   type ExpectationException = TestFailedException
   
@@ -48,7 +48,7 @@ trait AbstractMockFactory extends SuiteMixin with MockFactoryBase { this: Suite 
   }
 
   protected def newExpectationException(message: String, methodName: Option[Symbol]) =
-    new TestFailedException(_ => Some(message), None, failedCodeStackDepthFn(methodName))
+    new TestFailedException((_: StackDepthException) => Some(message), None, failedCodeStackDepthFn(methodName))
 
   protected var autoVerify = true
 }

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/MockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/MockFactory.scala
@@ -21,7 +21,7 @@
 package org.scalamock.scalatest
 
 import org.scalamock.clazz.Mock
-import org.scalatest.Suite
+import org.scalatest.TestSuite
 
 /**
  * Trait that can be mixed into a [[http://www.scalatest.org/ ScalaTest]] suite to provide
@@ -137,5 +137,4 @@ import org.scalatest.Suite
  * 
  * See [[org.scalamock]] for overview documentation.
  */
-trait MockFactory extends AbstractMockFactory with Mock { this: Suite =>
-}
+trait MockFactory extends AbstractMockFactory with Mock with TestSuite

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/PathMockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/PathMockFactory.scala
@@ -22,8 +22,8 @@ package org.scalamock.scalatest
 
 import org.scalamock.MockFactoryBase
 import org.scalamock.clazz.Mock
-import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{ SuiteMixin, Suite }
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import org.scalatest.{Suite, SuiteMixin}
 
 /**
  * Trait that can be mixed into org.scalatest.path.* specs (e.g. path.FunSpec).
@@ -33,13 +33,12 @@ import org.scalatest.{ SuiteMixin, Suite }
  *
  * See [[MockFactory]] for more information.
  */
-trait PathMockFactory extends SuiteMixin with MockFactoryBase with Mock {
-  this: Suite =>
-
+trait PathMockFactory extends SuiteMixin with MockFactoryBase with Mock { this: Suite =>
+  
   type ExpectationException = TestFailedException
 
   protected def newExpectationException(message: String, methodName: Option[Symbol]) =
-    new TestFailedException(_ => Some(message), None, failedCodeStackDepthFn(methodName))
+    new TestFailedException((_: StackDepthException) => Some(message), None, failedCodeStackDepthFn(methodName))
 
   /**
    * Verify all expectations.

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/proxy/MockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/proxy/MockFactory.scala
@@ -22,12 +22,11 @@ package org.scalamock.scalatest.proxy
 
 import org.scalamock.proxy.ProxyMockFactory
 import org.scalamock.scalatest.AbstractMockFactory
-import org.scalatest.Suite
+import org.scalatest.TestSuite
 
 /** Trait that can be mixed into a [[http://www.scalatest.org/ ScalaTest]] suite to provide
   * proxy mocking support.
   *
   * See [[org.scalamock]] for overview documentation.
   */
-trait MockFactory extends AbstractMockFactory with ProxyMockFactory { this: Suite =>
-}
+trait MockFactory extends AbstractMockFactory with ProxyMockFactory with TestSuite

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/BasicTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/BasicTest.scala
@@ -22,15 +22,14 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.FlatSpec
-import org.scalatest.ShouldMatchers
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
  *  Tests for mock defined in test case scope
  *
  *  Tests for issue #25
  */
-class BasicTest extends FlatSpec with ShouldMatchers with MockFactory {
+class BasicTest extends FlatSpec with Matchers with MockFactory {
 
   "ScalaTest suite" should "allow to use mock defined in test case scope" in {
     val mockedTrait = mock[TestTrait]

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/ErrorReportingTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/ErrorReportingTest.scala
@@ -22,15 +22,15 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.{ Args, FlatSpec, FunSuite, Reporter, ShouldMatchers, Suite }
-import org.scalatest.events.{ Event, TestFailed }
+import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
+
 import scala.language.postfixOps
 
 /**
  *  Tests that errors are reported correctly in ScalaTest suites
  */
-class ErrorReporting extends FlatSpec with ShouldMatchers with TestSuiteRunner {
+class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
 
   "ScalaTest suite" should "report unexpected call correctly" in {
     class TestedSuite extends FunSuite with MockFactory {

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/FixtureContextTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/FixtureContextTest.scala
@@ -23,14 +23,14 @@ package org.scalamock.test.scalatest
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
 import org.scalatest.FlatSpec
-import org.scalatest.ShouldMatchers
+import org.scalatest.Matchers
 
 /**
  *  Tests for mocks defined in fixture-contexts
  *
  *  Tests for issue #25
  */
-class FixtureContextTest extends FlatSpec with ShouldMatchers with MockFactory {
+class FixtureContextTest extends FlatSpec with Matchers with MockFactory {
 
   trait TestSetup {
     val mockedTrait = mock[TestTrait]

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
@@ -22,7 +22,7 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{ Matchers, path }
+import org.scalatest.{Matchers, path}
 
 class PathSpecTest extends path.FunSpec with Matchers with PathMockFactory {
 
@@ -47,17 +47,16 @@ class PathSpecTest extends path.FunSpec with Matchers with PathMockFactory {
     it("fails if top-level expectation is not met") {
       an[TestFailedException] should be thrownBy verifyExpectations()
     }
-  }
-
-  describe("PathSpec") {
-    val mockFun = mockFunction[String, Unit]("mockFun")
-
+  
     it("can have expectations checked at the end of root suite") {
+      val mockFun = mockFunction[String, Unit]("mockFun")
       mockFun expects "bottom-level"
+      val caught = intercept[TestFailedException] {
+        verifyExpectations()
+      }
+      caught.getMessage() should include("mockFun(bottom-level) once (never called - UNSATISFIED)")
     }
-
-    val testFailedException = trap({ verifyExpectations() }).asInstanceOf[TestFailedException]
-    testFailedException.getMessage() should include("mockFun(bottom-level) once (never called - UNSATISFIED)")
+    
   }
 
 }

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/StackableSuitesTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/StackableSuitesTest.scala
@@ -25,14 +25,14 @@ import org.scalamock.test.mockable.TestTrait
 import org.scalatest._
 import org.scalatest.events.TestSucceeded
 
-class StackableSuitesTest extends FlatSpec with ShouldMatchers with TestSuiteRunner {
+class StackableSuitesTest extends FlatSpec with Matchers with TestSuiteRunner {
 
   object EventLogger {
     var events: List[String] = List.empty
     def logEvent(event: String) = { events = events :+ event }
   }
 
-  trait SuiteWrapper extends SuiteMixin { this: Suite =>
+  trait SuiteWrapper extends SuiteMixin with TestSuite {
     abstract override def withFixture(test: NoArgTest): Outcome = {
       EventLogger.logEvent("SuiteWrapper setup")
       val outcome = super.withFixture(test)
@@ -41,7 +41,7 @@ class StackableSuitesTest extends FlatSpec with ShouldMatchers with TestSuiteRun
     }
   }
 
-  class TestedSuite extends FunSuite with SuiteWrapper with MockFactory with ShouldMatchers {
+  class TestedSuite extends FunSuite with SuiteWrapper with MockFactory with Matchers {
     test("execute block of code") {
       val mockedTrait = mock[TestTrait]
       (mockedTrait.oneParamMethod _).expects(1).onCall { arg: Int =>

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopeMockParallelTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopeMockParallelTest.scala
@@ -22,16 +22,14 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.FlatSpec
-import org.scalatest.ParallelTestExecution
-import org.scalatest.ShouldMatchers
+import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 
 /**
  *  Tests for mocks defined in suite scope (i.e. outside test case scope)
  *
  *  Tests for issue #25
  */
-class SuiteScopeMockParallelTest extends FlatSpec with ShouldMatchers with ParallelTestExecution with MockFactory {
+class SuiteScopeMockParallelTest extends FlatSpec with Matchers with ParallelTestExecution with MockFactory {
   // please note that this test suite mixes in ParallelTestExecution trait
 
   val mockWithoutExpectationsPredefined = mock[TestTrait]

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopePresetMockParallelTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopePresetMockParallelTest.scala
@@ -22,16 +22,14 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.FlatSpec
-import org.scalatest.ShouldMatchers
-import org.scalatest.ParallelTestExecution
+import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 
 /**
  *  Tests for mocks defined in suite scope (i.e. outside test case scope) with predefined expectations
  *
  *  Tests for issue #25
  */
-class SuiteScopePresetMockParallelTest extends FlatSpec with ShouldMatchers with ParallelTestExecution with MockFactory {
+class SuiteScopePresetMockParallelTest extends FlatSpec with Matchers with ParallelTestExecution with MockFactory {
   // please note that this test suite mixes in ParallelTestExecution trait
 
   val mockWithExpectationsPredefined = mock[TestTrait]

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopeProxyMockTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/SuiteScopeProxyMockTest.scala
@@ -20,19 +20,16 @@
 
 package org.scalamock.test.scalatest
 
-import org.scalamock.test.mockable.TestTrait
-import org.scalatest.FlatSpec
-import org.scalatest.ParallelTestExecution
-import org.scalatest.ShouldMatchers
-import org.scalatest.OneInstancePerTest
 import org.scalamock.scalatest.proxy.MockFactory
+import org.scalamock.test.mockable.TestTrait
+import org.scalatest._
 
 /**
  *  Tests for proxy mocks defined in suite scope (i.e. outside test case scope)
  *
  *  Test for issue #35
  */
-class SuiteScopeProxyMockTest extends FlatSpec with ShouldMatchers with OneInstancePerTest with MockFactory {
+class SuiteScopeProxyMockTest extends FlatSpec with Matchers with OneInstancePerTest with MockFactory {
   // please note that this test suite mixes in OneInstancePerTest trait
 
   val mockWithoutExpectationsPredefined = mock[TestTrait]

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/TestSuiteRunner.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/TestSuiteRunner.scala
@@ -19,13 +19,12 @@
 // THE SOFTWARE.
 
 package org.scalamock.test.scalatest
-import org.scalatest.events.{ Event, TestFailed }
-import org.scalatest.ShouldMatchers
-import org.scalatest.{ Args, Reporter, Suite }
+import org.scalatest.events.{Event, TestFailed}
+import org.scalatest._
 
 import scala.language.postfixOps
 
-trait TestSuiteRunner { this: ShouldMatchers =>
+trait TestSuiteRunner { this: Matchers =>
 
   /** Executes single ScalaTest test case and returns its outcome (i.e. either TestSucccess or TestFailure) */
   def runTestCase[T <: Suite](suite: T): Event = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,8 +23,8 @@ import Keys._
 import sbt.inc.Analysis
 
 object BuildSettings {
-  val buildVersion = "3.2.2"
-  val buildScalaVersion = "2.10.4"
+  val buildVersion = "3.3.0"
+  val buildScalaVersion = "2.10.6"
 
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "org.scalamock",
@@ -92,7 +92,7 @@ object ShellPrompt {
 }
 
 object Dependencies {
-  val scalatest =  "org.scalatest" %% "scalatest" % "2.2.4"
+  val scalatest =  "org.scalatest" %% "scalatest" % "3.0.0"
   val specs2 = "org.specs2" %% "specs2" % "2.4.16"
   val reflect = "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersion
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.12


### PR DESCRIPTION
Also bump ScalaMock version to 3.3.0. The ScalaTest 3.0.0 compatibility changes in this commit were originally committed by dvic on the master ScalaMock branch. This commit cherry-picks those changes and backports them to the Scala 2.10 branch.