### PR TITLE
AsyncMockFactory to fix issues with expectations and async test suites

### DIFF
--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AbstractAsyncMockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AbstractAsyncMockFactory.scala
@@ -1,0 +1,30 @@
+package org.scalamock.scalatest
+
+import org.scalatest._
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+
+import scala.concurrent.Future
+
+/**
+  * Created by Luiz Guilherme D'Abruzzo Pereira <luiz290788@gmail.com> on 22/12/16.
+  */
+trait AbstractAsyncMockFactory extends AsyncTestSuiteMixin with AsyncMockFactoryBase with AsyncTestSuite {
+
+  type ExpectationException = TestFailedException
+
+  abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
+    if (autoVerify) {
+      new FutureOutcome(withExpectations(super.withFixture(test).toFuture).recoverWith({
+        case t: Throwable => Future.successful(Exceptional(t))
+      }))
+    } else {
+      super.withFixture(test)
+    }
+  }
+
+  protected def newExpectationException(message: String, methodName: Option[Symbol]) =
+    new TestFailedException((_: StackDepthException) => Some(message), None, failedCodeStackDepthFn(methodName))
+
+  protected var autoVerify = true
+
+}

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AsyncMockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AsyncMockFactory.scala
@@ -1,0 +1,9 @@
+package org.scalamock.scalatest
+
+import org.scalamock.clazz.Mock
+import org.scalatest.AsyncTestSuite
+
+/**
+  * Created by Luiz Guilherme D'Abruzzo Pereira <luiz290788@gmail.com> on 22/12/16.
+  */
+trait AsyncMockFactory extends AbstractAsyncMockFactory with Mock with AsyncTestSuite

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
@@ -1,0 +1,66 @@
+package org.scalamock.scalatest
+
+import org.scalamock.clazz.Mock
+import org.scalamock.context.{CallLog, MockContext}
+import org.scalamock.function.MockFunctions
+import org.scalamock.handlers.UnorderedHandlers
+import org.scalamock.matchers.Matchers
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Created by Luiz Guilherme D'Abruzzo Pereira <luiz290788@gmail.com> on 22/12/16.
+  */
+trait AsyncMockFactoryBase extends MockContext with Mock with MockFunctions with Matchers {
+
+  //! TODO - https://issues.scala-lang.org/browse/SI-5831
+  implicit val _factory = this
+
+  implicit def executionContext: ExecutionContext
+
+  private def initializeExpectations() {
+    val initialHandlers = new UnorderedHandlers
+    callLog = new CallLog
+
+    expectationContext = initialHandlers
+    currentExpectationContext = initialHandlers
+  }
+
+  private def clearExpectations(): Unit = {
+    // to forbid setting expectations after verification is done
+    callLog = null
+    expectationContext = null
+    currentExpectationContext = null
+  }
+
+
+  def withExpectations[T](test: => Future[T]): Future[T] = {
+    if (expectationContext == null) {
+      // we don't reset expectations for the first test case to allow
+      // defining expectations in Suite scope and writing tests in OneInstancePerTest/isolated style
+      initializeExpectations()
+    }
+
+    val testResult = test
+    testResult.onFailure({
+      case _ => clearExpectations()
+    })
+    testResult.map(result => {
+      verifyExpectations()
+      result
+    })
+  }
+
+  private def verifyExpectations() {
+    callLog.foreach(expectationContext.verify(_))
+
+    val oldCallLog = callLog
+    val oldExpectationContext = expectationContext
+
+    clearExpectations()
+
+    if (!oldExpectationContext.isSatisfied)
+      reportUnsatisfiedExpectation(oldCallLog, oldExpectationContext)
+  }
+
+}

--- a/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/proxy/AsyncMockFactory.scala
+++ b/frameworks/scalatest/src/main/scala/org/scalamock/scalatest/proxy/AsyncMockFactory.scala
@@ -1,0 +1,10 @@
+package org.scalamock.scalatest.proxy
+
+import org.scalamock.proxy.ProxyMockFactory
+import org.scalamock.scalatest.AbstractAsyncMockFactory
+import org.scalatest.AsyncTestSuite
+
+/**
+  * Created by Luiz Guilherme D'Abruzzo Pereira <luiz290788@gmail.com> on 26/12/16.
+  */
+trait AsyncMockFactory  extends AbstractAsyncMockFactory with ProxyMockFactory with AsyncTestSuite


### PR DESCRIPTION
Add AsyncMockFactory to fix issues with AsyncTestSuite from scalatest.

The issue that we were facing was related to the number of calls that was expected for a certain method of a mock. It wasn't failing when we expected a call once and it was never called. The issue only happened because we were using AsyncFlatSpecLike that implements AsyncTestSuite and user a different withFixture method.

The solution was to create AbstractAsyncMockFactory that extends from AsyncTestSuite and implements the async withFixture. But for that to work, I needed to make withExpectations to work asynchronous as well.

Our tests are checking all the calls now and we were able to find some bugs with that so I want to share that with you. And let us know if there is a better solution for our problem.