### PR TITLE
Fixed Async Test Expectation Setup

### DIFF
--- a/shared/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
+++ b/shared/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
@@ -7,6 +7,7 @@ import org.scalamock.handlers.UnorderedHandlers
 import org.scalamock.matchers.Matchers
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 trait AsyncMockFactoryBase extends MockContext with Mock with MockFunctions with Matchers {
 
@@ -38,7 +39,10 @@ trait AsyncMockFactoryBase extends MockContext with Mock with MockFunctions with
       initializeExpectations()
     }
 
-    test onComplete (_ => clearExpectations())
+    test onComplete {
+      case Success(_) => ()
+      case Failure(_) => clearExpectations()
+    }
     test map { result =>
       verifyExpectations()
       result


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)

## Fixes

Fixes issue where racing condition in handling async test expectations in `AsyncMockFactoryBase` frequently cause NPE.

## Background Context

In order to use Async test in Scalatest integration, one needs to use `AsyncMockFactoryBase`. However, in 11cc112, `onComplete` was mistakenly used without matching only on failed tests. This has caused a racing condition when test is successful, thus causing NPE at `verifyExpectations` easily happen for async tests.
