### PR TITLE
Make sure there is no uninitialized variables in AsyncMockFactoryBase

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val quasiquotes = libraryDependencies ++= {
 }
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
-  scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature",
+  scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xcheckinit",
     "-target:jvm-" + (if (scalaVersion.value < "2.11") "1.7" else "1.8"))
 )
 

--- a/shared/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
+++ b/shared/src/main/scala/org/scalamock/scalatest/AsyncMockFactoryBase.scala
@@ -16,6 +16,8 @@ trait AsyncMockFactoryBase extends MockContext with Mock with MockFunctions with
 
   implicit def executionContext: ExecutionContext
 
+  initializeExpectations()
+
   private def initializeExpectations() {
     val initialHandlers = new UnorderedHandlers
     callLog = new CallLog


### PR DESCRIPTION
This avoids `scala.UninitializedFieldError` when run on scala 2.12
with `-Xcheckinit` compiler flag.

# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files (no new files)
* [x] I have added tests for any changed functionality (added compiler flag to build.sbt)

## Fixes

Fixes #226 

## Purpose

Call `initializeExpectations` in `AsyncMockFactoryBase` constructor to avoid uninitialized variables.
