### PR TITLE
scala-js 0.6.24

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtcrossproject.crossProject
+
 scalaVersion in ThisBuild := "2.11.11"
 crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.3", "2.13.0-M3")
 scalaJSUseRhino in ThisBuild := true
@@ -36,7 +38,7 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     "-target:jvm-" + (if (scalaVersion.value < "2.11") "1.7" else "1.8"))
 )
 
-lazy val examples = crossProject in file("examples") settings(
+lazy val examples = crossProject(JSPlatform, JVMPlatform) in file("examples") settings(
     commonSettings,
     name := "ScalaMock Examples",
     skip in publish := true,
@@ -50,7 +52,7 @@ lazy val `examples-js` = examples.js
 
 lazy val `examples-jvm` = examples.jvm
 
-lazy val scalamock = crossProject in file(".") settings(
+lazy val scalamock = crossProject(JSPlatform, JVMPlatform) in file(".") settings(
     commonSettings,
     publishTo := Some(
       if (isSnapshot.value)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes


## Purpose

update scala-js 0.6.24. migrate to sbt-crossproject plugin and fix some warnings in build.sbt

## Background Context

scala-js 0.6.22 does not support 2.13.0-M4. We should update if support latest Scala 2.13 milestone.

## References

- https://github.com/portable-scala/sbt-crossproject#migration-from-scalajs-default-crossproject
- https://www.scala-js.org/news/2018/05/22/announcing-scalajs-0.6.23/

