### PR TITLE
decode symbolic method name

### DIFF
--- a/shared/src/main/scala/org/scalamock/function/FakeFunction.scala
+++ b/shared/src/main/scala/org/scalamock/function/FakeFunction.scala
@@ -21,12 +21,13 @@
 package org.scalamock.function
 
 import org.scalamock.context.{MockContext, Call}
+import scala.reflect.NameTransformer
 
 // This has to be a separate trait, not a method in MockFunction, because
 // otherwise linearization will choose the MockFunctionN toString
 trait NiceToString { self: FakeFunction =>
 
-  override def toString = name.name.toString
+  override def toString = NameTransformer.decode(name.name.toString)
 }
 
 abstract class FakeFunction(protected val mockContext: MockContext, private[scalamock] val name: Symbol) {

--- a/shared/src/test/scala/com/paulbutcher/test/mock/MockNamingTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/mock/MockNamingTest.scala
@@ -43,7 +43,7 @@ class MockNamingTest extends IsolatedSpec {
   }
 
   it should "have a sensible method name when mocking an operator" in {
-    getMockMethodName(m.+ _) shouldBe "<mock> TestTrait.$plus" // TODO could be better
+    getMockMethodName(m.+ _) shouldBe "<mock> TestTrait.+"
   }
 
   it should "have a sensible method name when mocking polymorphic method" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Fixes TODO in `MockNamingTest.scala`

## Purpose

decode symbolic method name

## Background Context

## References

https://github.com/scala/scala/blob/v2.12.6/src/library/scala/reflect/NameTransformer.scala