### PR TITLE
MockFactory reporting unexpected calls at the end of each test

### DIFF
--- a/shared/src/main/scala/org/scalamock/context/CallLog.scala
+++ b/shared/src/main/scala/org/scalamock/context/CallLog.scala
@@ -35,7 +35,10 @@ private[scalamock] class CallLog {
   }
   
   def foreach(f: Call => Unit) = log foreach f
-  
+
+  def isEmpty = log.isEmpty
+  def nonEmpty = log.nonEmpty
+
   override def toString = log mkString("  ", "\n  ", "")
   
   private val log = new ListBuffer[Call]


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* ~~[ ] I have added copyright headers to new files~~
* [ ] I have added tests for any changed functionality

## Fixes

Fixes #223 

## Purpose

Introduces `MockFactoryRecordingUnexpectedCalls`, which reports all unexpected calls after each test. This is usable especially with asynchronous tests since the original exception can be silently dropped.

## Background Context

> Why did you take this approach?

Fully backward compatible, records all unexpected call to be replayed later. Then optionally mixed in Factory verifies the empty call log of unexpected calls.

This approach is 1) backward compatible since it does not change current behavior, 2) still eagerly fails on an unexpected call, and 3) optionally fails again in the event the original failure was ignored.