### PR TITLE
Use linesIterator instead of lines (fix #268)

### DIFF
--- a/shared/src/main/scala/org/scalamock/handlers/Handlers.scala
+++ b/shared/src/main/scala/org/scalamock/handlers/Handlers.scala
@@ -32,7 +32,7 @@ private[scalamock] abstract class Handlers extends Handler {
   
   override def toString = 
     handlers.map { h =>
-      h.toString.lines.toArray.map { l => "  " + l}
+      h.toString.linesIterator.toArray.map { l => "  " + l}
     }.flatten.mkString(s"$prefix {\n", "\n", "\n}")
   
   protected val handlers = new ListBuffer[Handler]


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Fixes

Fixes #268

## Purpose

Avoid deprecated method `lines`

## Background Context

See discussion in https://github.com/scala/bug/issues/11125
