### PR TITLE
Updated the ScalaMock to work with ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaVersion in ThisBuild := "2.11.12"
 crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.8", "2.13.0")
 scalaJSUseRhino in ThisBuild := true
 
-lazy val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
+lazy val scalatest = "org.scalatest" %% "scalatest" % "3.1.0"
 lazy val specs2 = "org.specs2" %% "specs2-core" % "4.5.1"
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
@@ -50,3 +50,7 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform) in file("examples") se
 
 lazy val `examples-js` = examples.js
 lazy val `examples-jvm` = examples.jvm
+
+scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix" % "3.1.0.0"
+scalacOptions += "-Yrangepos"
+addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,3 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform) in file("examples") se
 
 lazy val `examples-js` = examples.js
 lazy val `examples-jvm` = examples.jvm
-
-scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix" % "3.1.0.0"
-scalacOptions += "-Yrangepos"
-addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB

--- a/examples/shared/src/test/scala/com/example/function/HigherOrderFunctionsTest.scala
+++ b/examples/shared/src/test/scala/com/example/function/HigherOrderFunctionsTest.scala
@@ -21,9 +21,9 @@
 package com.example.function
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class HigherOrderFunctionsTest extends FreeSpec with MockFactory {
+class HigherOrderFunctionsTest extends AnyFreeSpec with MockFactory {
 
   import language.postfixOps
 

--- a/examples/shared/src/test/scala/com/example/function/mockitostyle/HigherOrderFunctionsTest.scala
+++ b/examples/shared/src/test/scala/com/example/function/mockitostyle/HigherOrderFunctionsTest.scala
@@ -21,9 +21,9 @@
 package com.example.function.mockitostyle
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class HigherOrderFunctionsTest extends FreeSpec with MockFactory {
+class HigherOrderFunctionsTest extends AnyFreeSpec with MockFactory {
   import language.postfixOps
 
   "HigherOrderFunctionsTest" - {

--- a/examples/shared/src/test/scala/com/example/makro/ControllerTest.scala
+++ b/examples/shared/src/test/scala/com/example/makro/ControllerTest.scala
@@ -20,12 +20,12 @@
 
 package com.example.makro
 
-import org.scalatest.FunSuite
 import org.scalamock.scalatest.MockFactory
 import scala.math.{Pi, sqrt}
 import com.example.{Controller, Turtle}
+import org.scalatest.funsuite.AnyFunSuite
  
-class ControllerTest extends FunSuite with MockFactory {
+class ControllerTest extends AnyFunSuite with MockFactory {
  
   test("draw line") {
     val mockTurtle = mock[Turtle]

--- a/examples/shared/src/test/scala/com/example/makro/OrderTest.scala
+++ b/examples/shared/src/test/scala/com/example/makro/OrderTest.scala
@@ -20,13 +20,13 @@
 
 package com.example.makro
 
-import org.scalatest.WordSpec
 import org.scalamock.scalatest.MockFactory
 import com.example.{Order, Warehouse}
+import org.scalatest.wordspec.AnyWordSpec
 
 // This is a reworked version of the example from Martin Fowler's article
 // Mocks Aren't Stubs http://martinfowler.com/articles/mocksArentStubs.html
-class OrderTest extends WordSpec with MockFactory {
+class OrderTest extends AnyWordSpec with MockFactory {
   import language.postfixOps
   
   "An order" when {

--- a/examples/shared/src/test/scala/com/example/makro/mockitostyle/ControllerTest.scala
+++ b/examples/shared/src/test/scala/com/example/makro/mockitostyle/ControllerTest.scala
@@ -22,11 +22,11 @@ package com.example.makro.mockitostyle
 
 import com.example.{Controller, Turtle}
 
-import org.scalatest.FunSuite
 import org.scalamock.scalatest.MockFactory
 import scala.math.{Pi, sqrt}
+import org.scalatest.funsuite.AnyFunSuite
  
-class ControllerTest extends FunSuite with MockFactory {
+class ControllerTest extends AnyFunSuite with MockFactory {
   import scala.language.postfixOps
  
   test("draw line") {

--- a/examples/shared/src/test/scala/com/example/makro/mockitostyle/OrderTest.scala
+++ b/examples/shared/src/test/scala/com/example/makro/mockitostyle/OrderTest.scala
@@ -22,12 +22,12 @@ package com.example.makro.mockitostyle
 
 import com.example.{Order, Warehouse}
 
-import org.scalatest.WordSpec
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.wordspec.AnyWordSpec
 
 // This is a reworked version of the example from Martin Fowler's article
 // Mocks Aren't Stubs http://martinfowler.com/articles/mocksArentStubs.html
-class OrderTest extends WordSpec with MockFactory {
+class OrderTest extends AnyWordSpec with MockFactory {
   import language.postfixOps
   
   "An order" when {

--- a/js/src/test/scala/org/scalamock/jstests/JSNativeTest.scala
+++ b/js/src/test/scala/org/scalamock/jstests/JSNativeTest.scala
@@ -1,10 +1,11 @@
 package org.scalamock.jstests
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @js.native
 @JSGlobal
@@ -12,7 +13,7 @@ class FakeJSNativeClass extends js.Object {
   def fillText(text: String, x: Double, y: Double, maxWidth: Double = js.native): Unit = js.native
 }
 
-class JSNativeTest extends FlatSpec with MockFactory with Matchers {
+class JSNativeTest extends AnyFlatSpec with MockFactory with Matchers {
   ignore should "create a mock for method with 'js.native' default args" in {
 //    val _ = mock[FakeJSNativeClass]
   }

--- a/js/src/test/scala/org/scalamock/jstests/matchers/ArgThatTest.scala
+++ b/js/src/test/scala/org/scalamock/jstests/matchers/ArgThatTest.scala
@@ -21,9 +21,10 @@
 package org.scalamock.jstests.matchers
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ArgThatTest extends FlatSpec with Matchers with MockFactory {
+class ArgThatTest extends AnyFlatSpec with Matchers with MockFactory {
 
   behavior of "ArgThat"
 

--- a/jvm/src/test/scala/com.paulbutcher.test/matchers/ArgThatTest.scala
+++ b/jvm/src/test/scala/com.paulbutcher.test/matchers/ArgThatTest.scala
@@ -21,9 +21,10 @@
 package com.paulbutcher.test.matchers
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ArgThatTest extends FlatSpec with Matchers with MockFactory {
+class ArgThatTest extends AnyFlatSpec with Matchers with MockFactory {
 
   behavior of "ArgThat"
 

--- a/jvm/src/test/scala/com.paulbutcher.test/mock/MockTestJvm.scala
+++ b/jvm/src/test/scala/com.paulbutcher.test/mock/MockTestJvm.scala
@@ -21,10 +21,11 @@
 package com.paulbutcher.test.mock
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FreeSpec, Matchers}
 import com.paulbutcher.test._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MockTestJvm extends FreeSpec with MockFactory with Matchers {
+class MockTestJvm extends AnyFreeSpec with MockFactory with Matchers {
   
   autoVerify = false
   

--- a/jvm/src/test/scala/com.paulbutcher.test/proxy/ProxyMockManyParamsTest.scala
+++ b/jvm/src/test/scala/com.paulbutcher.test/proxy/ProxyMockManyParamsTest.scala
@@ -22,9 +22,9 @@ package com.paulbutcher.test.proxy
 
 import com.paulbutcher.test.{ManyParamsClass, ManyParamsTrait}
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ProxyMockManyParamsTest extends FreeSpec with MockFactory {
+class ProxyMockManyParamsTest extends AnyFreeSpec with MockFactory {
 
   autoVerify = false
 

--- a/jvm/src/test/scala/com.paulbutcher.test/proxy/ProxyMockTest.scala
+++ b/jvm/src/test/scala/com.paulbutcher.test/proxy/ProxyMockTest.scala
@@ -22,9 +22,9 @@ package com.paulbutcher.test.proxy
 
 import com.paulbutcher.test.TestTrait
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ProxyMockTest extends FreeSpec with MockFactory {
+class ProxyMockTest extends AnyFreeSpec with MockFactory {
   
   autoVerify = false
   

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+
+addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.1.0" cross CrossVersion.full)
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,3 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
-
-addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.1.0" cross CrossVersion.full)
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
-

--- a/shared/src/test/scala/com/paulbutcher/test/IsolatedSpec.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/IsolatedSpec.scala
@@ -21,9 +21,11 @@
 package com.paulbutcher.test
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest, Suite}
+import org.scalatest.{OneInstancePerTest, Suite}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-abstract class IsolatedSpec extends FlatSpec with MockFactory with Matchers with OneInstancePerTest {
+abstract class IsolatedSpec extends AnyFlatSpec with MockFactory with Matchers with OneInstancePerTest {
 
   def repeat(n: Int)(what: => Unit): Unit = {
     for (i <- 0 until n)

--- a/shared/src/test/scala/com/paulbutcher/test/matchers/ArgCaptureTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/matchers/ArgCaptureTest.scala
@@ -22,10 +22,11 @@ package com.paulbutcher.test.matchers
 
 import com.paulbutcher.test.TestTrait
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalamock.matchers.ArgCapture._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ArgCaptureTest extends FlatSpec with Matchers with MockFactory {
+class ArgCaptureTest extends AnyFlatSpec with Matchers with MockFactory {
   behavior of "CaptureOne"
 
   it should "capture arguments - string" in {

--- a/shared/src/test/scala/com/paulbutcher/test/matchers/MatchAnyTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/matchers/MatchAnyTest.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test.matchers
 
 import org.scalamock.matchers.MatchAny
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class MatchAnyTest extends FlatSpec {
+class MatchAnyTest extends AnyFlatSpec {
 
   "MatchAny" should "match anything" in {
     assert(new MatchAny === 1.0)

--- a/shared/src/test/scala/com/paulbutcher/test/matchers/MatchEpsilonTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/matchers/MatchEpsilonTest.scala
@@ -22,9 +22,9 @@ package com.paulbutcher.test.matchers
 
 import org.scalamock._
 import org.scalamock.matchers.MatchEpsilon
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class MatchEpsilonTest extends FreeSpec {
+class MatchEpsilonTest extends AnyFreeSpec {
 
   "MatchEpsilon should" - {
     "match anything that's close to the given value" in {

--- a/shared/src/test/scala/com/paulbutcher/test/matchers/MockParameterTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/matchers/MockParameterTest.scala
@@ -21,9 +21,10 @@
 package com.paulbutcher.test.matchers
 
 import org.scalamock.matchers.{MatchAny, MatchEpsilon, MockParameter}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MockParameterTest extends FreeSpec with Matchers {
+class MockParameterTest extends AnyFreeSpec with Matchers {
   
   "A mock parameter should" - {
     "be equal" - {

--- a/shared/src/test/scala/com/paulbutcher/test/mock/MockFunctionTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/mock/MockFunctionTest.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test.mock
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class MockFunctionTest extends FreeSpec with MockFactory {
+class MockFunctionTest extends AnyFreeSpec with MockFactory {
   
   autoVerify = false
   

--- a/shared/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -22,7 +22,6 @@ package com.paulbutcher.test.mock
 
 import org.scalamock.function.FunctionAdapter1
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{TypeTag, typeTag}
@@ -30,8 +29,10 @@ import scala.util.{Failure, Try}
 
 import com.paulbutcher.test._
 import some.other.pkg._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MockTest extends FreeSpec with MockFactory with Matchers {
+class MockTest extends AnyFreeSpec with MockFactory with Matchers {
   
   autoVerify = false
   

--- a/shared/src/test/scala/com/paulbutcher/test/mock/MockTestManyParams.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/mock/MockTestManyParams.scala
@@ -23,8 +23,10 @@ package com.paulbutcher.test.mock
 import com.paulbutcher.test.{ManyParamsClass, ManyParamsTrait}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MockTestManyParams extends FreeSpec with MockFactory with Matchers {
+class MockTestManyParams extends AnyFreeSpec with MockFactory with Matchers {
   autoVerify = false
 
   "Mocks should" - {

--- a/shared/src/test/scala/com/paulbutcher/test/stub/StubFunctionTest.scala
+++ b/shared/src/test/scala/com/paulbutcher/test/stub/StubFunctionTest.scala
@@ -21,9 +21,9 @@
 package com.paulbutcher.test.stub
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class StubFunctionTest extends FreeSpec with MockFactory {
+class StubFunctionTest extends AnyFreeSpec with MockFactory {
   
   autoVerify = false
   

--- a/shared/src/test/scala/org/scalamock/jstests/matchers/MatchEpsilonTest.scala
+++ b/shared/src/test/scala/org/scalamock/jstests/matchers/MatchEpsilonTest.scala
@@ -22,9 +22,9 @@ package org.scalamock.jstests.matchers
 
 import org.scalamock._
 import org.scalamock.matchers.MatchEpsilon
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class MatchEpsilonTest extends FreeSpec {
+class MatchEpsilonTest extends AnyFreeSpec {
 
   "MatchEpsilon should" - {
     "match anything that's close to the given value" in {

--- a/shared/src/test/scala/org/scalamock/test/scalatest/AsyncMockFactoryNoDuplicatedRun.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/AsyncMockFactoryNoDuplicatedRun.scala
@@ -21,9 +21,10 @@
 package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.AsyncMockFactory
-import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.Future
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Test to ensure AsyncMockFactory only run test once

--- a/shared/src/test/scala/org/scalamock/test/scalatest/BasicAsyncTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/BasicAsyncTest.scala
@@ -21,8 +21,9 @@
 package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.AsyncMockFactory
-import org.scalatest.{AsyncFlatSpec, Matchers}
 import scala.concurrent.Future
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for issue #215

--- a/shared/src/test/scala/org/scalamock/test/scalatest/BasicTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/BasicTest.scala
@@ -22,14 +22,15 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for mock defined in test case scope
  *
  *  Tests for issue #25
  */
-class BasicTest extends FlatSpec with Matchers with MockFactory {
+class BasicTest extends AnyFlatSpec with Matchers with MockFactory {
 
   "ScalaTest suite" should "allow to use mock defined in test case scope" in {
     val mockedTrait = mock[TestTrait]

--- a/shared/src/test/scala/org/scalamock/test/scalatest/ConcurrencyTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/ConcurrencyTest.scala
@@ -22,13 +22,13 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.FlatSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ConcurrencyTest extends FlatSpec with MockFactory {
+class ConcurrencyTest extends AnyFlatSpec with MockFactory {
   behavior of "ScalaMock"
 
   it should "work with Futures" in {

--- a/shared/src/test/scala/org/scalamock/test/scalatest/ErrorReportingTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/ErrorReportingTest.scala
@@ -26,14 +26,17 @@ import org.scalatest._
 import org.scalatest.exceptions.TestFailedException
 
 import scala.language.postfixOps
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests that errors are reported correctly in ScalaTest suites
  */
-class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
+class ErrorReportingTest extends AnyFlatSpec with Matchers with TestSuiteRunner {
 
   "ScalaTest suite" should "report unexpected call correctly" in {
-    class TestedSuite extends FunSuite with MockFactory {
+    class TestedSuite extends AnyFunSuite with MockFactory {
       test("execute block of code") {
         val mockedTrait = mock[TestTrait]
         mockedTrait.oneParamMethod(3)
@@ -46,7 +49,7 @@ class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
   }
 
   it should "report unexpected call correctly when expectations are set" in {
-    class TestedSuite extends FunSuite with MockFactory {
+    class TestedSuite extends AnyFunSuite with MockFactory {
       test("execute block of code") {
         val mockedTrait = mock[TestTrait]
         (mockedTrait.oneParamMethod _).expects(1).returning("one")
@@ -61,7 +64,7 @@ class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
   }
 
   it should "not hide NullPointerException" in {
-    class TestedSuite extends FunSuite with MockFactory {
+    class TestedSuite extends AnyFunSuite with MockFactory {
       test("execute block of code") {
         val mockedTrait = mock[TestTrait]
         (mockedTrait.oneParamMethod _).expects(1).returning("one")
@@ -75,7 +78,7 @@ class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
   }
 
   it should "report default mock names" in {
-    class TestedSuite extends FunSuite with MockFactory {
+    class TestedSuite extends AnyFunSuite with MockFactory {
       test("execute block of code") {
         val mockA = mock[TestTrait]
         val mockB = mock[TestTrait]
@@ -101,7 +104,7 @@ class ErrorReportingTest extends FlatSpec with Matchers with TestSuiteRunner {
   }
 
   it should "report unexpected calls in readable manner" in {
-    class TestedSuite extends FunSuite with MockFactory {
+    class TestedSuite extends AnyFunSuite with MockFactory {
       val suiteScopeMock = mock[TestTrait]("suite mock")
       (() => suiteScopeMock.noParamMethod()).expects().returning("two").twice()
 

--- a/shared/src/test/scala/org/scalamock/test/scalatest/FixtureContextTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/FixtureContextTest.scala
@@ -22,14 +22,15 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for mocks defined in fixture-contexts
  *
  *  Tests for issue #25
  */
-class FixtureContextTest extends FlatSpec with Matchers with MockFactory {
+class FixtureContextTest extends AnyFlatSpec with Matchers with MockFactory {
 
   trait TestSetup {
     val mockedTrait = mock[TestTrait]

--- a/shared/src/test/scala/org/scalamock/test/scalatest/MixedMockFactoryTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/MixedMockFactoryTest.scala
@@ -1,9 +1,10 @@
 package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MixedMockFactory
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MixedMockFactoryTest extends FlatSpec with MixedMockFactory with Matchers {
+class MixedMockFactoryTest extends AnyFlatSpec with MixedMockFactory with Matchers {
   "mixed mocks" should "work" in {
     trait Foo {
       def getI: Int

--- a/shared/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
@@ -22,9 +22,11 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{Matchers, path}
+import org.scalatest.path
+import org.scalatest.funspec
+import org.scalatest.matchers.should.Matchers
 
-class PathSpecTest extends path.FunSpec with Matchers with PathMockFactory {
+class PathSpecTest extends funspec.PathAnyFunSpec with Matchers with PathMockFactory {
   override def newInstance = new PathSpecTest
 
   describe("PathSpec") {

--- a/shared/src/test/scala/org/scalamock/test/scalatest/StackableSuitesTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/StackableSuitesTest.scala
@@ -24,8 +24,11 @@ import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
 import org.scalatest._
 import org.scalatest.events.TestSucceeded
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class StackableSuitesTest extends FlatSpec with Matchers with TestSuiteRunner {
+class StackableSuitesTest extends AnyFlatSpec with Matchers with TestSuiteRunner {
 
   object EventLogger {
     var events: List[String] = List.empty
@@ -41,7 +44,7 @@ class StackableSuitesTest extends FlatSpec with Matchers with TestSuiteRunner {
     }
   }
 
-  class TestedSuite extends FunSuite with SuiteWrapper with MockFactory with Matchers {
+  class TestedSuite extends AnyFunSuite with SuiteWrapper with MockFactory with Matchers {
     test("execute block of code") {
       val mockedTrait = mock[TestTrait]
       (mockedTrait.oneParamMethod _).expects(1).onCall { arg: Int =>

--- a/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopeMockParallelTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopeMockParallelTest.scala
@@ -22,14 +22,16 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
+import org.scalatest.ParallelTestExecution
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for mocks defined in suite scope (i.e. outside test case scope)
  *
  *  Tests for issue #25
  */
-class SuiteScopeMockParallelTest extends FlatSpec with Matchers with ParallelTestExecution with MockFactory {
+class SuiteScopeMockParallelTest extends AnyFlatSpec with Matchers with ParallelTestExecution with MockFactory {
   // please note that this test suite mixes in ParallelTestExecution trait
 
   override def newInstance = new SuiteScopeMockParallelTest

--- a/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopePresetMockParallelTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopePresetMockParallelTest.scala
@@ -22,14 +22,16 @@ package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory
 import org.scalamock.test.mockable.TestTrait
-import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
+import org.scalatest.ParallelTestExecution
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for mocks defined in suite scope (i.e. outside test case scope) with predefined expectations
  *
  *  Tests for issue #25
  */
-class SuiteScopePresetMockParallelTest extends FlatSpec with Matchers with ParallelTestExecution with MockFactory {
+class SuiteScopePresetMockParallelTest extends AnyFlatSpec with Matchers with ParallelTestExecution with MockFactory {
   // please note that this test suite mixes in ParallelTestExecution trait
 
   override def newInstance = new SuiteScopePresetMockParallelTest

--- a/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopeProxyMockTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/SuiteScopeProxyMockTest.scala
@@ -23,13 +23,15 @@ package org.scalamock.test.scalatest
 import org.scalamock.scalatest.proxy.MockFactory
 import org.scalamock.test.mockable.TestTrait
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  *  Tests for proxy mocks defined in suite scope (i.e. outside test case scope)
  *
  *  Test for issue #35
  */
-class SuiteScopeProxyMockTest extends FlatSpec with Matchers with OneInstancePerTest with MockFactory {
+class SuiteScopeProxyMockTest extends AnyFlatSpec with Matchers with OneInstancePerTest with MockFactory {
   // please note that this test suite mixes in OneInstancePerTest trait
 
   override def newInstance = new SuiteScopeProxyMockTest

--- a/shared/src/test/scala/org/scalamock/test/scalatest/TestSuiteRunner.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/TestSuiteRunner.scala
@@ -19,8 +19,9 @@
 // THE SOFTWARE.
 
 package org.scalamock.test.scalatest
-import org.scalatest.events.{Event, TestFailed}
 import org.scalatest._
+import org.scalatest.events.{Event, TestFailed}
+import org.scalatest.matchers.should.Matchers
 
 import scala.language.postfixOps
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files (N/A)
* [ ] I have added tests for any changed functionality (N/A)

## Fixes
Updated the ScalaTest library dependency to `3.1.0`

## Purpose
Updated the ScalaTest library dependency to `3.1.0`

What does this PR do?
It updates the ScalaMock to work with latest ScalaTest dependency `3.1.0`

Why did you take this approach?
So that we can leverage ScalaMock with latest ScalaTest released version

## References  
http://www.scalatest.org/release_notes/3.1.0
https://github.com/scalatest/autofix/tree/master/3.1.x
https://scalameta.org/docs/semanticdb/guide.html

Are there any relevant issues / PRs / mailing lists discussions?
None that I found