### PR TITLE
Fix a typo in MockFactory ScalaDoc

### DIFF
--- a/shared/src/main/scala/org/scalamock/scalatest/MockFactory.scala
+++ b/shared/src/main/scala/org/scalamock/scalatest/MockFactory.scala
@@ -61,7 +61,7 @@ import org.scalatest.TestSuite
  * 
  * This way in the suite scope you can declare instance variables (e.g. mocks) that will be used by
  * multiple test cases and perform common test case setup (e.g. set up some mock expectations).
- * Because each test cases has fresh instance variables different test cases do not interfere with each
+ * Because each test case has fresh instance variables different test cases do not interfere with each
  * other.
  * 
  * {{{


### PR DESCRIPTION
Just a simple fix for a typo I noticed while reading the MockFactory
ScalaDoc. Hopefully this make it nicer/easier to read for others.

# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

No open issues related to this PR.

## Purpose

Fixes a typo in ScalaDoc.

## Background Context

N/A

## References

N/A
