### PR TITLE
Scaladoc correction

### DIFF
--- a/shared/src/main/scala/org/scalamock/package.scala
+++ b/shared/src/main/scala/org/scalamock/package.scala
@@ -173,7 +173,7 @@ package org
  * 
  * {{{
  * val mockIncrement = mockFunction[Int, Int]
- * m expects (*) onCall { _ + 1 }
+ * mockIncrement expects (*) onCall { _ + 1 }
  * }}}
  * 
  * ===Overloaded, curried and polymorphic methods===


### PR DESCRIPTION
# Pull Request Checklist

* [✓] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [✓] I have added copyright headers to new files
* [✓] I have added tests for any changed functionality

## Fixes

Fixes #406 

## Purpose

This corrects a mistaken code segment in the Scaladoc comment. Also, it adds a missing end-of-line character on the last line of this source file.

## Background Context

N/A

## References

N/A
