### PR TITLE
fix: make all CallLog operations synchronized

### DIFF
--- a/shared/src/main/scala/org/scalamock/context/CallLog.scala
+++ b/shared/src/main/scala/org/scalamock/context/CallLog.scala
@@ -34,9 +34,13 @@ private[scalamock] class CallLog {
     log += call
   }
   
-  def foreach(f: Call => Unit) = log foreach f
+  def foreach(f: Call => Unit) = this.synchronized {
+    log.foreach(f)
+  }
   
-  override def toString = log mkString("  ", "\n  ", "")
+  override def toString = this.synchronized {
+    log.mkString("  ", "\n  ", "")
+  }
   
   private val log = new ListBuffer[Call]
 }


### PR DESCRIPTION
# Pull Request Checklist

* [*] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [*] I have added copyright headers to new files
* [*] I have added tests for any changed functionality

## Purpose

We are getting some ConcurrentModificationExceptions here. The exact use-case is not particularly well-designed but essentially what happens is that if you call a method on a mock in a different thread than the one that does something like `eventually { (mock.foo ).verify(bar) }`, you will get a CME. 

Both [edge|use]-case and this fix are admittedly weird and there's a number of better ways to solve this but given that original code admits just using`synchronized`, I thought this would be OK.