### PR TITLE
Enhance union/intersection type support

### DIFF
--- a/shared/src/test/scala-3/com/paulbutcher/test/Scala3Spec.scala
+++ b/shared/src/test/scala-3/com/paulbutcher/test/Scala3Spec.scala
@@ -28,6 +28,173 @@ class Scala3Spec extends AnyFunSpec with MockFactory with Matchers {
     m.method(1, new A with B) shouldBe 0
   }
 
+  it("mock intersection type with type parameter from trait") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericIntersection[A] {
+      def methodWithGenericIntersection(x: A & B): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection[C]]
+
+    val obj = new B with C {}
+
+    (m.methodWithGenericIntersection _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+  it("mock intersection type with left type parameter from method") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericIntersection {
+      def methodWithGenericIntersection[A](x: A & B): Unit
+
+      def methodWithGenericUnion[A](x: A | B): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection]
+
+    val obj = new C with B {}
+
+    (m.methodWithGenericIntersection[C] _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+  it("mock intersection type with right type parameter from method") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericIntersection {
+      def methodWithGenericIntersection[A](x: B & A): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection]
+
+    val obj = new B with C {}
+
+    (m.methodWithGenericIntersection[C] _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+  it("mock intersection type with both type parameters from method") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericIntersection {
+      def methodWithGenericIntersection[A, B](x: A & B): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection]
+
+    val obj = new B with C {}
+
+    (m.methodWithGenericIntersection[B, C] _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+
+  it("mock intersection type with more then two types from method") {
+
+    trait B
+
+    trait C
+
+    trait D
+
+    trait TraitWithGenericIntersection {
+      def methodWithGenericIntersection[A, B, C](x: A & B & C): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection]
+
+    val obj = new B with C with D {}
+
+    (m.methodWithGenericIntersection[B, C, D] _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+  it("mock intersection type with more then two types from method, one of witch is stable") {
+
+    trait B
+
+    trait C
+
+    trait D
+
+    trait TraitWithGenericIntersection {
+      def methodWithGenericIntersection[A, B](x: A & D & B): Unit
+    }
+
+    val m = mock[TraitWithGenericIntersection]
+
+    val obj = new B with C with D {}
+
+    (m.methodWithGenericIntersection[B, C] _).expects(obj).returns(())
+
+    m.methodWithGenericIntersection(obj)
+  }
+
+  it("mock union type with left type parameter from method") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericUnion {
+
+      def methodWithGenericUnion[A](x: A | B): Unit
+    }
+
+    val m = mock[TraitWithGenericUnion]
+
+    val obj1 = new C {}
+    val obj2 = new B {}
+
+    (m.methodWithGenericUnion[C] _).expects(obj1).returns(())
+    (m.methodWithGenericUnion[C] _).expects(obj2).returns(())
+
+    m.methodWithGenericUnion(obj1)
+    m.methodWithGenericUnion(obj2)
+  }
+
+  it("mock union type with right type parameter from method") {
+
+    trait B
+
+    trait C
+
+    trait TraitWithGenericUnion {
+
+      def methodWithGenericUnion[A](x: B | A): Unit
+    }
+
+    val m = mock[TraitWithGenericUnion]
+
+    val obj1 = new C {}
+    val obj2 = new B {}
+
+    (m.methodWithGenericUnion[C] _).expects(obj1).returns(())
+    (m.methodWithGenericUnion[C] _).expects(obj2).returns(())
+
+    m.methodWithGenericUnion(obj1)
+    m.methodWithGenericUnion(obj2)
+  }
+
   it("mock methods returning function") {
     trait Test {
       def method(x: Int): Int => String


### PR DESCRIPTION
Union/intersection type having type from method type args causes compile time error.
This PR fixes it

Fixes #514



