### PR TITLE
Permit mocking stackable trait pattern in scala 3

### DIFF
--- a/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
+++ b/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
@@ -124,7 +124,8 @@ private[clazz] object MockMaker:
               privateWithin = Symbol.noSymbol
             )
 
-        List(mockFunctionSym, overrideSym)
+        if (definition.symbol.flags.is(Flags.Artifact)) Nil
+        else List(mockFunctionSym, overrideSym)
       },
       selfType = None
     )
@@ -143,7 +144,9 @@ private[clazz] object MockMaker:
       ClassDef(
         cls = classSymbol,
         parents = parents,
-        body = defaultMockName :: mockableDefinitions.flatMap { definition =>
+        body = defaultMockName :: mockableDefinitions.flatMap {
+          case definition if definition.symbol.flags.is(Flags.Artifact) => Nil
+          case definition =>
           val mockFunctionValDef: ValDef =
             val valSym = classSymbol.declaredField(definition.mockValName)
             val mockFunctionClassSymbol = valSym.typeRef.classSymbol.get

--- a/shared/src/test/scala/org/scalamock/test/scalatest/AbstractOverrideMethodTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/AbstractOverrideMethodTest.scala
@@ -1,0 +1,18 @@
+package org.scalamock.test.scalatest
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AbstractOverrideMethodTest extends AnyFlatSpec with Matchers with MockFactory {
+  class A extends B with D
+  trait B extends C { def foo(): Int = 1 }
+  trait C { def foo(): Int }
+  trait D extends C { abstract override def foo(): Int = super.foo() * 2 }
+
+  "ScalaTest suite" should "permit mocking classes build with stackable trait pattern" in {
+    val mockedClass = mock[A]
+    (mockedClass.foo _).expects().returning(42)
+    mockedClass.foo() shouldBe 42
+  }
+}

--- a/shared/src/test/scala/org/scalamock/test/scalatest/AbstractOverrideMethodTest.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/AbstractOverrideMethodTest.scala
@@ -1,3 +1,23 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package org.scalamock.test.scalatest
 
 import org.scalamock.scalatest.MockFactory


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Fixes mocking classes that implement the stackable trait pattern (i.e. `abstract override def`) in scala 3
