### PR TITLE
fix: cast args when applying mockFunctionValDef in scala 3

### DIFF
--- a/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
+++ b/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
@@ -192,7 +192,7 @@ private[clazz] object MockMaker:
                       Select.unique(
                         Apply(
                           Select.unique(Ref(mockFunctionValDef.symbol), "apply"),
-                          args.flatten.collect { case t: Term => t }
+                          args.flatten.collect { case t: Term => Select.unique(t, "asInstanceOf") }
                         ),
                         "asInstanceOf"
                       ),

--- a/shared/src/test/scala/org/scalamock/test/scalatest/TypeParamOnDef.scala
+++ b/shared/src/test/scala/org/scalamock/test/scalatest/TypeParamOnDef.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2011-2015 ScalaMock Contributors (https://github.com/paulbutcher/ScalaMock/graphs/contributors)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package org.scalamock.test.scalatest
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+trait Bar
+case class Baz(s: String) extends Bar
+
+trait Foo {
+  def p[T <: Bar](gen: Seq[T], t: Seq[T] => Seq[String]): Seq[String] = t(gen)
+  def q[T <: Bar](gen: Seq[T]): Seq[String] = gen.map(_.toString)
+}
+
+class TypeParamOnFunctionArgToMethod extends AnyFlatSpec with Matchers with MockFactory {
+
+  "TypeParamOnFunctionArgToMethod suite" should "permit mocking a method that takes a function w/ input parameterised by fn type param" in {
+    val mockedTrait = mock[Foo]
+    (mockedTrait.p[Baz](_:Seq[Baz], _: Seq[?] => Seq[String])).expects(Seq(Baz("one")), *).returning(Seq("one"))
+    (mockedTrait.q[Baz](_:Seq[Baz])).expects(Seq(Baz("one"))).returning(Seq("one"))
+
+    mockedTrait.p(Seq(Baz("one")), (_:Seq[Baz]).map(_.toString)) shouldBe Seq("one")
+    mockedTrait.q(Seq(Baz("one"))) shouldBe Seq("one")
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Whilst mocking a trait or class with a method that took a type parameter worked in scala 3 for many cases, it did not work when the type parameter was used as the input for a function arg to that method. The newly-added test case failed in those instances with the following:
```
[error] 43 |    val mockedTrait = mock[Foo]
[error]    |                               ^
[error]    |                               Found:    (t : Seq[Toot] => Seq[String])
[error]    |                               Required: Seq[?] => Seq[String]
[error]    |
[error]    | longer explanation available when compiling with `-explain`
```

## Purpose

This pr casts the args when passing them to the mock method implementation, which avoids the above error.

## Background Context

This seemed the least intrusive way of getting the new test case to work
