### PR TITLE
Remove scala.reflect.Selectable from generated mock type

### DIFF
--- a/shared/src/main/scala-3/org/scalamock/clazz/Mock.scala
+++ b/shared/src/main/scala-3/org/scalamock/clazz/Mock.scala
@@ -24,16 +24,14 @@ import org.scalamock.context.MockContext
 import org.scalamock.function.*
 import org.scalamock.util.Defaultable
 
-import scala.reflect.Selectable
-
 trait Mock:
   import scala.language.implicitConversions
 
-  inline def mock[T](implicit mockContext: MockContext): T & Selectable = ${MockImpl.mock[T]('{mockContext})}
-  inline def stub[T](implicit mockContext: MockContext): T & Selectable = ${MockImpl.stub[T]('{mockContext})}
+  inline def mock[T](implicit mockContext: MockContext): T = ${MockImpl.mock[T]('{mockContext})}
+  inline def stub[T](implicit mockContext: MockContext): T = ${MockImpl.stub[T]('{mockContext})}
 
-  inline def mock[T](mockName: String)(implicit mockContext: MockContext) : T & Selectable = ${MockImpl.mockWithName[T]('{mockName})('{mockContext})}
-  inline def stub[T](mockName: String)(implicit mockContext: MockContext): T & Selectable = ${MockImpl.stubWithName[T]('{mockName})('{mockContext})}
+  inline def mock[T](mockName: String)(implicit mockContext: MockContext) : T = ${MockImpl.mockWithName[T]('{mockName})('{mockContext})}
+  inline def stub[T](mockName: String)(implicit mockContext: MockContext): T = ${MockImpl.stubWithName[T]('{mockName})('{mockContext})}
 
   inline implicit def toMockFunction0[R: Defaultable](inline f: () => R): MockFunction0[R] = ${MockImpl.toMockFunction0[R]('{f})('{summon[Defaultable[R]]})}
   inline implicit def toMockFunction1[T1, R: Defaultable](inline f: T1 => R): MockFunction1[T1, R] = ${MockImpl.toMockFunction1[T1, R]('{f})('{summon[Defaultable[R]]})}

--- a/shared/src/main/scala-3/org/scalamock/clazz/MockImpl.scala
+++ b/shared/src/main/scala-3/org/scalamock/clazz/MockImpl.scala
@@ -27,20 +27,19 @@ import scala.quoted.*
 import org.scalamock.util.Defaultable
 import MockFunctionFinder.findMockFunction
 
-import scala.reflect.Selectable
 
 @scala.annotation.experimental
 private[clazz] object MockImpl:
-  def mock[T: Type](mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T & Selectable] =
+  def mock[T: Type](mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T] =
     MockMaker.instance[T](MockType.Mock, mockContext, name = None)
 
-  def stub[T: Type](mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T & Selectable] =
+  def stub[T: Type](mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T] =
     MockMaker.instance[T](MockType.Stub, mockContext, name = None)
 
-  def mockWithName[T: Type](mockName: Expr[String])(mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T & Selectable] =
+  def mockWithName[T: Type](mockName: Expr[String])(mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T] =
     MockMaker.instance[T](MockType.Mock, mockContext, Some(mockName))
 
-  def stubWithName[T: Type](mockName: Expr[String])(mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T & Selectable] =
+  def stubWithName[T: Type](mockName: Expr[String])(mockContext: Expr[MockContext])(using quotes: Quotes): Expr[T] =
     MockMaker.instance[T](MockType.Stub, mockContext, Some(mockName))
 
 

--- a/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
+++ b/shared/src/main/scala-3/org/scalamock/clazz/MockMaker.scala
@@ -28,7 +28,7 @@ import scala.reflect.Selectable
 private[clazz] object MockMaker:
   val MockDefaultNameValName = "mock$special$mockName"
 
-  def instance[T: Type](mockType: MockType, ctx: Expr[MockContext], name: Option[Expr[String]])(using quotes: Quotes): Expr[T & Selectable] =
+  def instance[T: Type](mockType: MockType, ctx: Expr[MockContext], name: Option[Expr[String]])(using quotes: Quotes): Expr[T] =
     val utils = Utils(using quotes)
     import utils.quotes.reflect.*
     val tpe = TypeRepr.of[T]


### PR DESCRIPTION
Remove scala.reflect.Selectable from generated mock type. It has no use outside off the library and may cause effects
