### PR TITLE
fix ConcurrentModificationException from CallLog

### DIFF
--- a/shared/src/main/scala/org/scalamock/context/CallLog.scala
+++ b/shared/src/main/scala/org/scalamock/context/CallLog.scala
@@ -34,9 +34,9 @@ private[scalamock] class CallLog {
     log += call
   }
   
-  def foreach(f: Call => Unit) = log foreach f
+  def foreach(f: Call => Unit) = this.synchronized { log foreach f }
   
-  override def toString = log mkString("  ", "\n  ", "")
+  override def toString = this.synchronized { log mkString("  ", "\n  ", "") }
   
   private val log = new ListBuffer[Call]
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Fixes `ConcurrentModificationException` (c.f. comment on https://github.com/paulbutcher/ScalaMock/pull/527)
The actual fix is the same as the one proposed in https://github.com/paulbutcher/ScalaMock/pull/462, but this also adds a test that fails on scala 2.13 & 3 without the fix.
The test is a little weird, but I couldn't write one that replicated the bug that wasn't a bit kooky....
