### PR TITLE
Scalamock for ZIO Test PoC

### DIFF
--- a/core/shared/src/main/scala/org/scalamock/scalamockz/README.md
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/README.md
@@ -1,0 +1,229 @@
+# scalamockz
+
+A library for working with ScalaMock in ZIO Test.
+
+Table of Contents:
+- [Quick Start](#quick-start)
+- [Setting up mock expectations](#setting-up-mock-expectations)
+- [Stubs in Record-then-Verify style](#stubs-in-record-then-verify-style)
+- [Injecting mocks and stubs into ZLayer](#injecting-mocks-and-stubs-into-zlayer)
+- [Effect call verification](#effect-call-verification)
+- [Call order verification](#call-order-verification)
+
+## Quick Start
+
+```scala
+import org.scalamock.scalamockz._
+import zio.test._
+import zio._
+
+// ScalamockZSpec — a trait with everything needed for working with ScalaMock in ZIO Test
+object ApiServiceSpec extends ScalamockZSpec {
+
+  override def spec: MockedSpec =
+    suite("ApiServiceSpec")(
+      test("return greeting")(
+        for {
+          // Setting up expectations — how the mock should be called and what it should return
+          _ <- ZIO.serviceWith[UserService] { mock =>
+            (mock.getUserName _).expects(4).returnsZIO("Agent Smith")
+          }
+          // Calling the tested code
+          result <- ZIO.serviceWithZIO[ApiService](_.getGreeting(4))
+        } yield assertTrue(result == "Hello, Agent Smith!")
+      )
+    ).provideSome(ApiService.layer, mock[UserService]) // Providing the required mock in the test
+}
+```
+
+## Setting up mock expectations
+
+To set up mock expectations, you need to obtain the mock from the ZIO Environment and then call the ScalaMock DSL:
+
+```scala
+ZIO.serviceWith[UserService] { mock =>
+  (mock.getName _).expects(4).returnsZIO("Agent Smith")
+}
+```
+
+You can use DSL methods to set up expectations just like in ScalaMock for ScalaTest.
+
+Examples of using this DSL can be found in [ScalaMock's feature documentation](https://scalamock.org/user-guide/features/), under ScalaMock (not ScalaMock 7!).
+
+Additionally, there are helpers for mocking ZIO methods:
+
+```scala
+// shortcut for returns(ZIO.succeed("Agent Smith")
+(mock.getName _).expects(4).returnsZIO("Agent Smith")
+
+// shortcut for returns(ZIO.fail(new Exception("test"))
+(mock.getName _).expects(4).failsZIO(new Exception("test"))
+
+// shortcut for returns(ZIO.die(new RuntimeException("death"))
+(mock.getName _).expects(4).diesZIO(new RuntimeException("death"))
+```
+
+From the [above-mentioned documentation](https://scalamock.org/user-guide/features/), all features work in scalamockz except Ordering.
+
+Thus, the following features are supported:
+- Argument Matching
+- Call counts
+- Returning values
+- Throwing exceptions (however, when mocking ZIO methods, it is better to use `failsZIO()` or `diesZIO()`)
+- Call handlers
+
+Ordering is also supported, but with some limitations.
+If you need to specify the call order of mocks, refer to the section [Call order verification](#call-order-verification) below.
+
+## Stubs in Record-then-Verify style
+
+https://scalamock.org/user-guide/mocking_style/
+
+In ScalaMock, there are not only mocks but also stubs. These are also supported in scalamockz:
+
+```scala
+object ApiServiceSpec extends ScalamockZSpec {
+
+  override def spec: MockedSpec =
+    suite("ApiServiceSpec")(
+      test("return greeting")(
+        for {
+          // Setting up expectations — how the stub may (but does not have to) be called, and what it should return.
+          _ <- ZIO.serviceWith[UserService] { stub =>
+            (stub.getUserName _).when(*).returnsZIO("Agent Smith")
+          }
+          // Calling the tested code
+          result <- ZIO.serviceWithZIO[ApiService](_.getGreeting(4))
+          // Verifying that stub was called as expected
+          _ <- ZIO.serviceWith[UserService] { stub =>
+            (stub.getUserName _).verify(4)
+          }
+        } yield assertTrue(result == "Hello, Agent Smith!")
+      )
+    ).provideSome(ApiService.layer, stub[UserService]) // Providing the required stub in the test
+}
+```
+
+This allows writing tests in the arrange-act-assert style, which in some cases leads to more readable code.
+
+## Injecting mocks and stubs into ZLayer
+
+When setting up expectations, we require a mock of the appropriate type to be available in the ZIO Environment.
+Now we need to inject this mock into the ZIO Environment.
+
+For this, you should use the `mock[A]` or `stub[A]` method, which returns a `URLayer[ScalamockZFactory, A]`.
+This is a recipe for creating a mock or stub that needs to be injected into the tested code through `ZLayer`:
+
+```scala
+override def spec: MockedSpec =
+  suite("ApiServiceSpec")(
+    test("return greeting")(
+      // Test code mocking UserService and AuthService...
+    )
+  ).provideSome(ApiService.layer, mock[UserService], stub[AuthService])
+```
+
+Note: We cannot use `provide()` here because `ScalamockZFactory` is not provided in this case.
+It is provided in `ScalamockZSpec`, and the library user does not need to create it.
+It is only necessary to specify (via `provideSome`) that it will be created outside of the test, later.
+
+`ScalamockZFactory` is an object that creates mocks from the `mock[A]` recipe and verifies expectations after each test.
+
+It is created separately for each test, ensuring that mocks are independent across tests.
+
+**Warning:** Injecting mocks through `provideSomeShared()` will cause the test to fail with an internal ScalaMock error:
+
+```
+assertion failed: Null expectation context - missing withExpectations?
+```
+
+This happens because expectations in scalamockz must be set up for each test separately.
+Thus, mocks should be created separately for each test, not shared between tests.
+
+## Effect call verification
+
+ScalaMock for ScalaTest can verify that a method was called.
+However, if we mock a method that returns an effect, we cannot check that the effect was actually called.
+
+To avoid this, in scalamockz, mocks from ScalaMock are additionally wrapped to verify that the effect was called.
+
+For example, here’s a service with a bug:
+
+```scala
+trait UserService {
+  def getUserName(id: Int): UIO[String]
+  def setGreeting(greeting: String): UIO[Unit]
+}
+
+class ApiService(userService: UserService) {
+
+  def setGreeting(userId: Int): UIO[Unit] =
+    for {
+      userName <- userService.getUserName(userId)
+      greeting = s"Hello, $userName!"
+      _ = userService.setGreeting(greeting) // Effect is not invoked in this case!
+    } yield ()
+}
+```
+
+Here’s a test for it:
+
+```scala
+test("set greeting for user")(
+  for {
+    _ <- ZIO.serviceWith[UserService] { mock =>
+      (mock.getUserName _).expects(4).returnsZIO("Agent Smith")
+      (mock.setGreeting _).expects("Hello, Agent Smith!").returnsZIO(())
+    }
+    _ <- ZIO.serviceWithZIO[ApiService](_.setGreeting(4))
+  } yield assertCompletes
+)
+```
+
+This test fails:
+
+```
+Unsatisfied expectation:
+ 
+Expected:
+inAnyOrder {
+  <mock-1> UserService.getUserName(4) once (called once)
+  <mock-1> UserService.setGreeting(Hello, Agent Smith!) once (never called - UNSATISFIED)
+}
+
+Actual:
+  <mock-1> UserService.getUserName(4)
+```
+
+This allows us to catch bugs caused by forgotten effect calls, unlike ScalaMock for ScalaTest.
+
+In scalamockz, this works by default for all methods returning `ZIO` (including `Task`, `URIO`, etc.).
+No additional configuration is needed for this.
+
+Additionally, methods returning non-`ZIO` can also be mocked.
+This mocking works just like in ScalaMock for ScalaTest — without verifying the effect call.
+
+## Call order verification
+
+The order of mocked method calls can be verified.
+In ScalaMock for ScalaTest, the methods `inSequence` and `inAnyOrder` are used for this.
+If neither of these methods is called, ScalaMock does not check the call order by default.
+
+In scalamockz, `inSequence` returns an effect.
+For example, this test verifies both that the methods are called and that `isAuthorized` is called before `getUserName`.
+
+```scala
+test("return greeting if user is authorized")(
+  for {
+    authService <- ZIO.service[AuthService]
+    userService <- ZIO.service[UserService]
+    _ <- inSequence {
+      (authService.isAuthorized _).expects(4).returnsZIO(true)
+      (userService.getUserName _).expects(4).returnsZIO("Agent Smith")
+    }
+    result <- ZIO.serviceWithZIO[ApiService](_.getGreeting(4))
+  } yield assertTrue(result == "Hello, Agent Smith!")
+)
+```
+
+If `inSequence` is not called, the call order verification will not occur. There is no explicit `inAnyOrder` method in scalamockz.

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/ScalamockZFactory.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/ScalamockZFactory.scala
@@ -1,0 +1,118 @@
+package org.scalamock.scalamockz
+
+import org.scalamock.clazz.Mock
+import org.scalamock.context.{CallLog, MockContext}
+import org.scalamock.handlers.{Handlers, OrderedHandlers, UnorderedHandlers}
+import org.scalamock.scalamockz.ScalamockZFactory.ExpectationException
+import org.scalamock.scalamockz.macros.CheckEffectInvocationMacros
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import zio.{IO, UIO, ULayer, ZIO, ZLayer}
+
+/**
+ * Provides a MockContext for creating mocks in zio-test.
+ * Can initialize the MockContext for use in tests.
+ * Also verifies mock invocations.
+ */
+sealed trait ScalamockZFactory {
+  // It has to be made public so that the RunMockedMacros macro works from tests.
+  val mockContext: MockContext
+  private[scalamockz] def initializeExpectations(): UIO[Unit]
+  private[scalamockz] def verifyExpectations(): IO[ExpectationException, Unit]
+  private[scalamockz] def inSequence[T](what: => T): T
+}
+
+object ScalamockZFactory extends Mock {
+
+  type ExpectationException = TestFailedException
+
+  private[scalamockz] val live: ULayer[ScalamockZFactory] = ZLayer.succeed(new Live())
+  private[scalamockz] val dummy: ULayer[ScalamockZFactory] = ZLayer.succeed(Dummy)
+
+  import scala.language.experimental.macros
+  import scala.language.implicitConversions
+
+  override def mock[T](implicit mockContext: MockContext): T = macro CheckEffectInvocationMacros.mock[T]
+  override def stub[T](implicit mockContext: MockContext): T = macro CheckEffectInvocationMacros.stub[T]
+
+  override def mock[T](mockName: String)(implicit mockContext: MockContext): T =
+    macro CheckEffectInvocationMacros.mockWithName[T]
+
+  override def stub[T](mockName: String)(implicit mockContext: MockContext): T =
+    macro CheckEffectInvocationMacros.stubWithName[T]
+
+  private[scalamockz] class Live extends ScalamockZFactory with MockContext {
+
+    val mockContext: MockContext = this
+
+    // todo: copy-paste from org.scalamock.scalatest, it shouldn't be here
+    override type ExpectationException = ScalamockZFactory.ExpectationException
+
+    private def failedCodeStackDepthFn(methodName: Option[Symbol]): StackDepthException => Int = e => {
+      e.getStackTrace.indexWhere { s =>
+        !s.getClassName.startsWith("org.scalamock") && !s.getClassName.startsWith("org.scalatest") &&
+        !(s.getMethodName == "newExpectationException") && !(s.getMethodName == "reportUnexpectedCall") &&
+        methodName.forall(s.getMethodName != _.name)
+      }
+    }
+
+    override protected def newExpectationException(message: String, methodName: Option[Symbol]) =
+      new TestFailedException((_: StackDepthException) => Some(message), None, failedCodeStackDepthFn(methodName))
+
+    // Copy-paste from org.scalamock.MockFactoryBase
+    def initializeExpectations(): UIO[Unit] = ZIO.succeed {
+      val initialHandlers = new UnorderedHandlers
+      callLog = new CallLog
+
+      expectationContext = initialHandlers
+      currentExpectationContext = initialHandlers
+    }
+
+    private def clearExpectations(): UIO[Unit] = ZIO.succeed {
+      // to forbid setting expectations after verification is done
+      callLog = null
+      expectationContext = null
+      currentExpectationContext = null
+    }
+
+    def verifyExpectations(): IO[ExpectationException, Unit] = {
+      for {
+        _ <- ZIO.succeed(callLog.foreach { call =>
+          val _ = expectationContext.verify(call)
+        })
+        oldCallLog = callLog
+        oldExpectationContext = expectationContext
+        _ <- clearExpectations()
+        _ <- ZIO.when(!oldExpectationContext.isSatisfied) {
+          ZIO.fail(
+            newExpectationException(s"Unsatisfied expectation:\n\n${errorContext(oldCallLog, oldExpectationContext)}")
+          )
+        }
+      } yield ()
+
+    }
+
+    override private[scalamockz] def inSequence[T](what: => T): T = {
+      inContext(new OrderedHandlers)(what)
+    }
+
+    private def inContext[T](context: Handlers)(what: => T): T = {
+      currentExpectationContext.add(context)
+      val prevContext = currentExpectationContext
+      currentExpectationContext = context
+      val r = what
+      currentExpectationContext = prevContext
+      r
+    }
+  }
+
+  /**
+   * A placeholder to prevent compiler errors in ScalamockZSpec.
+   * It is not actually used.
+   */
+  private[scalamockz] object Dummy extends ScalamockZFactory {
+    override lazy val mockContext: MockContext = ???
+    override private[scalamockz] def initializeExpectations(): UIO[Unit] = ???
+    override private[scalamockz] def verifyExpectations(): UIO[Unit] = ???
+    override private[scalamockz] def inSequence[T](what: => T): T = ???
+  }
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/ScalamockZSpec.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/ScalamockZSpec.scala
@@ -1,0 +1,137 @@
+package org.scalamock.scalamockz
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.matchers.Matchers
+import org.scalamock.scalamockz.internal.{MockContextStub, ScalamockZSpecSetup}
+import org.scalamock.scalamockz.macros.LayeredMockMacros
+import org.scalamock.scalamockz.syntax.MockConvertions
+import zio.{IO, Scope, UIO, URIO, URLayer, ZIO}
+import zio.test.{Spec, TestEnvironment}
+
+/**
+ * Base trait for tests with mocks using zio-test.
+ * 
+ * Basic usage example:
+ * 
+ * {{{
+ * object ExampleSpec extends ScalamockZSpec {
+ *
+ *   trait Service {
+ *     def f(x: Int): UIO[String]
+ *   }
+ *
+ *   override def spec: MockedSpec =
+ *     suite("ExampleSpec")(
+ *       test("succeed if function is invoked as expected") {
+ *         for {
+ *           _ <- ZIO.serviceWith[Service] { mock =>
+ *             (mock.f _).expects(42).returns(ZIO.succeed("-42"))
+ *           }
+ *           value <- ZIO.serviceWithZIO[Service](_.f(42))
+ *         } yield assertTrue(value == "-42")
+ *       },
+ *     ).provideSome[ScalamockZFactory](mock[Service])
+ * } 
+ * }}}
+ */
+trait ScalamockZSpec extends ScalamockZSpecSetup with Matchers with MockContextStub with MockConvertions {
+
+  import scala.language.experimental.macros
+
+  /**
+   * Returns a recipe for creating a mock for testing in the Expectations-First style.
+   * https://scalamock.org/user-guide/mocking_style/
+   *
+   * Typically, it should be provided to the layers where the mock is required.
+   */
+  def mock[A]: URLayer[ScalamockZFactory, A] =
+    macro LayeredMockMacros.mockImpl[A]
+
+  /**
+   * Returns a recipe for creating a stub for testing in the Record-then-Verify style.
+   * https://scalamock.org/user-guide/mocking_style/
+   *
+   * Typically, it should be provided to the layers where the stub is required.
+   */
+  def stub[A]: URLayer[ScalamockZFactory, A] =
+    macro LayeredMockMacros.stubImpl[A]
+
+  // Shortcuts for working with mocks in tests using ScalamockZSpec.
+  type MockedSpec = Spec[TestEnvironment with Scope with ScalamockZFactory, Any]
+  type MockedLayer[A] = URLayer[ScalamockZFactory, A]
+
+  // Wrappers for more convenient mocking of methods that return ZIO.
+  // Naming follows the pattern from Scalamock:
+  // - for returning success: returnsZIO/returningZIO
+  // - for returning error: failsZIO/failingZIO
+  // - for returning a defect: dieZIO/dyingZIO
+  implicit class RichIOHandler[E, A](val handler: CallHandler[IO[E, A]]) {
+
+    def returnsZIO(value: A): handler.Derived =
+      handler.returns(ZIO.succeed(value))
+
+    def returningZIO(value: A): handler.Derived =
+      returnsZIO(value)
+
+    def failsZIO(error: E): handler.Derived =
+      handler.returns(ZIO.fail(error))
+
+    def failingZIO(error: E): handler.Derived =
+      failsZIO(error)
+
+    def diesZIO(error: Throwable): handler.Derived =
+      handler.returns(ZIO.die(error))
+
+    def dyingZIO(error: Throwable): handler.Derived =
+      diesZIO(error)
+  }
+
+  // RichIOHandler does not resolve when the method returns UIO
+  // so we need to explicitly add extension methods for UIO
+  implicit class RichUIOHandler[A](val handler: CallHandler[UIO[A]]) {
+
+    def returnsZIO(value: A): handler.Derived =
+      handler.returns(ZIO.succeed(value))
+
+    def returningZIO(value: A): handler.Derived =
+      returnsZIO(value)
+
+    def diesZIO(error: Throwable): handler.Derived =
+      handler.returns(ZIO.die(error))
+
+    def dyingZIO(error: Throwable): handler.Derived =
+      diesZIO(error)
+  }
+
+  /**
+   * Allows defining a sequence of mock method calls:
+   *
+   * {{{
+   * ZIO.serviceWithZIO[Service] { mock =>
+   *   inSequence {
+   *     (mock.f _).expects(42).returnsZIO("-42")
+   *     (mock.f _).expects(43).returnsZIO("1")
+   *   }
+   * }
+   * }}}
+   *
+   * You can also define a sequence of calls across multiple mocks, for example:
+   *
+   * {{{
+   * for {
+   *   authService <- ZIO.service[AuthService]
+   *   userService <- ZIO.service[UserService]
+   *   _ <- inSequence {
+   *     (authService.isAuthorized _).expects(4).returnsZIO(true)
+   *     (userService.getUserName _).expects(4).returnsZIO("Agent Smith")
+   *   }
+   * } yield ()
+   * }}}
+   *
+   * The test will fail if the expected sequence of calls is not followed.
+   */
+  def inSequence[A](what: => A): URIO[ScalamockZFactory, Unit] =
+    ZIO.serviceWith[ScalamockZFactory] { factory =>
+      val _ = factory.inSequence(what)
+    }
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/SimplerZIOMockMigration.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/SimplerZIOMockMigration.scala
@@ -1,0 +1,67 @@
+package org.scalamock.scalamockz
+
+import org.scalamock.scalamockz.macros.LayeredMockMacros
+import zio.{Tag, URIO, URLayer}
+
+/**
+ * Can simplify migration from zio-mock to scalamockz.
+ * Not required when writing tests on scalamockz from scratch.
+ */
+trait SimplerZIOMockMigration {
+
+  import scala.language.experimental.macros
+
+  /**
+   * Creates a Layer that generates a new mock.
+   *
+   * WARN: Use with caution, and pass only one Layer of each type into the test!
+   *
+   * In zio-mock, there is an implicit conversion from `Expectation[A]` to `ULayer[A]`.
+   * In scalamockz, `URIO[A with ScalamockZFactory, Any]` is used as a replacement for `Expectation`.
+   * To simplify the migration from zio-mock to scalamockz, a similar conversion is provided to avoid rewriting
+   * how expectations are passed into layers.
+   *
+   * This conversion is not declared as `implicit` to avoid introducing unintended bugs, and it must be invoked manually.
+   *
+   * WARN: Careless passing of ZIO into layers may lead to unexpected behavior,
+   * such as creating mocks that were not intended.
+   *
+   * Example:
+   * {{{
+   * test("creation of two mocks") {
+   *   val layer1 = createMockedLayer(
+   *     ZIO.serviceWith[Service] { mock =>
+   *       (mock.f _).expects(42).returnsZIO("-42")
+   *     }
+   *   )
+   *   val layer2 = createMockedLayer(
+   *     ZIO.serviceWith[Service] { mock =>
+   *       (mock.f _).expects(43).returnsZIO("-43")
+   *     }
+   *   )
+   *   val effect = for {
+   *     _ <- ZIO.serviceWith[Service] { mock =>
+   *       (mock.f _).expects(42).returnsZIO("-42")
+   *     }
+   *     value <- ZIO.serviceWithZIO[Service](_.f(42))
+   *   } yield assertTrue(value == "-42")
+   *   effect.provideSomeLayer(layer1 ++ layer2)
+   * }
+   * }}}
+   *
+   * In this test, two mocks are created — one expects to be called with the argument `42`,
+   * and the other with `43` (and likely creating TWO mocks is not what the developer intended).
+   *
+   * For tests written from scratch using scalamockz, it is generally
+   * not recommended to use this conversion and the SimplerZIOMockMigration trait.
+   * It is intended only to simplify migration from zio-mock to scalamockz.
+   *
+   * Furthermore, in some cases where the test does not involve complex logic with layers,
+   * you can skip using this trait during migration by avoiding the need to pass expectations into layers.
+   */
+  def createMockedLayer[A](
+      expectations: URIO[A with ScalamockZFactory, Any]
+    )(implicit tag: Tag[A]
+    ): URLayer[ScalamockZFactory, A] =
+    macro LayeredMockMacros.mockedImpl[A]
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/internal/MockContextStub.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/internal/MockContextStub.scala
@@ -1,0 +1,12 @@
+package org.scalamock.scalamockz.internal
+
+import org.scalamock.context.MockContext
+
+/**
+ * A placeholder to prevent compiler errors in ScalamockZSpec.
+ * It is not actually used.
+ */
+private[scalamockz] trait MockContextStub extends MockContext {
+  override type ExpectationException = Throwable
+  override protected def newExpectationException(message: String, methodName: Option[Symbol]) = ???
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/internal/ScalamockZSpecSetup.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/internal/ScalamockZSpecSetup.scala
@@ -1,0 +1,25 @@
+package org.scalamock.scalamockz.internal
+
+import org.scalamock.scalamockz.ScalamockZFactory
+import zio.test.TestAspect.{after, before}
+import zio.{Chunk, ZIO, ZLayer}
+import zio.test.{testEnvironment, TestAspect, TestAspectAtLeastR, TestEnvironment, ZIOSpec}
+
+private[scalamockz] trait ScalamockZSpecSetup extends ZIOSpec[TestEnvironment with ScalamockZFactory] {
+
+  override def bootstrap: ZLayer[Any, Any, TestEnvironment with ScalamockZFactory] =
+    // A placeholder layer to prevent compiler errors regarding a missing ScalamockZFactory.
+    // This factory isn't actually used. The `live` implementation from aspects takes precedence.
+    ZLayer.make[TestEnvironment with ScalamockZFactory](testEnvironment, ScalamockZFactory.dummy)
+
+  // If the list of aspects here is updated, make sure to also update it in ScalamockZSpecSpec.aspects!
+  override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment with ScalamockZFactory]] = super.aspects :+
+    before(ZIO.serviceWithZIO[ScalamockZFactory](_.initializeExpectations())) :+
+    // We need to use orDie because the `aspects` method has the type
+    // TestAspect[..., LowerE = Nothing, UpperE = Any],
+    // while this expression without orDie has the type
+    // TestAspect[..., LowerE = ExpectationException, UpperE = Nothing],
+    // and `LowerE` is covariant.
+    after(ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations().orDie)) :+
+    TestAspect.fromLayer(ScalamockZFactory.live)
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/macros/CheckEffectInvocationMacros.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/macros/CheckEffectInvocationMacros.scala
@@ -1,0 +1,137 @@
+package org.scalamock.scalamockz
+package macros
+
+import org.scalamock.clazz.MockImpl.MockMaker
+import org.scalamock.context.MockContext
+import org.scalamock.util.MacroAdapter
+import scala.language.existentials
+
+/**
+ * Creates mocks that validate whether an effect has actually been executed.
+ *
+ * In classic Scalamock, the following code will not cause the test to fail:
+ *
+ * {{{
+ * // Test code
+ * val m = mock[Service]
+ * (m.f _).expects(42).returning(ZIO.succeed(42))
+ *
+ * // Production code
+ * for {
+ *   _ <- ZIO.unit
+ *   _ = service.f(42) // The effect isn't actually executed!
+ * } yield ()
+ * }}}
+ *
+ * This macro ensures that the mocked effect is actually executed by wrapping the method in `suspendSucceed()`.
+ *
+ * How it works: A classic mock generates code similar to this (simplified for clarity):
+ *
+ * {{{
+ * // Inside Scalamock
+ * var callLog = new CallLog
+ *
+ * // Generated in the test, instead of mock[Service]
+ * val m = new Mock[Service] {
+ *   def f(x: Int): UIO[String] = {
+ *     val call = new Call(this, arguments)
+ *     callLog += call
+ *   }
+ * }
+ * }}}
+ *
+ * When the method is called, its invocation is recorded in the callLog.
+ * Scalamock considers the method as invoked.
+ *
+ * We wrap this mock like this:
+ *
+ * {{{
+ * val m = new Mock[Service] {
+ *   def f(x: Int): UIO[String] = ZIO.suspendSucceed {
+ *     val call = new Call(this, arguments)
+ *     callLog += call
+ *   }
+ * }
+ * }}}
+ *
+ * Now, the method isn't immediately recorded in the callLog.
+ * It is only added when the effect `f(x)` is actually executed.
+ */
+private[scalamockz] object CheckEffectInvocationMacros {
+
+  import MacroAdapter.Context
+
+  def mock[T: c.WeakTypeTag](c: Context)(mockContext: c.Expr[MockContext]): c.Expr[T] = {
+    make[T](c)(mockContext)(stub = false, mockName = None)
+  }
+
+  def stub[T: c.WeakTypeTag](c: Context)(mockContext: c.Expr[MockContext]): c.Expr[T] = {
+    make[T](c)(mockContext)(stub = true, mockName = None)
+  }
+
+  def mockWithName[T: c.WeakTypeTag](
+      c: Context
+    )(mockName: c.Expr[String]
+    )(mockContext: c.Expr[MockContext]): c.Expr[T] = {
+    make[T](c)(mockContext)(stub = false, mockName = Some(mockName))
+  }
+
+  def stubWithName[T: c.WeakTypeTag](
+      c: Context
+    )(mockName: c.Expr[String]
+    )(mockContext: c.Expr[MockContext]): c.Expr[T] = {
+    make[T](c)(mockContext)(stub = true, mockName = Some(mockName))
+  }
+
+  private def make[T: c.WeakTypeTag](
+      c: Context
+    )(mockContext: c.Expr[MockContext]
+    )(stub: Boolean,
+      mockName: Option[c.Expr[String]]): c.Expr[T] = {
+    val maker = MockMaker[T](c)(mockContext, stub, mockName)
+    val originalTree = maker.make
+    val transformedTree = transformAst(c)(originalTree.tree)
+    c.Expr[T](transformedTree)
+  }
+
+  /**
+   * Scalamock generates code like this (you can inspect it using `println(tree)`):
+   *
+   * {{{
+   * {
+   *   final class $anon extends org.scalamock.scalamockz.ScalamockZSpecSpec.Service {
+   *     def <init>() = {
+   *       super.<init>();
+   *       ()
+   *     };
+   *     val mock$special$mockName = factory$macro$1.get[org.scalamock.scalamockz.ScalamockZFactory]((zio.`package`.Tag.apply[org.scalamock.scalamockz.ScalamockZFactory]((izumi.reflect.Tag.apply[org.scalamock.scalamockz.ScalamockZFactory](classOf[org.scalamock.scalamockz.ScalamockZFactory], izumi.reflect.macrortti.LightTypeTag.parse[Nothing]((-1099772752: Int), ("\u0004\u0000\u0001*org.scalamock.scalamockz.ScalamockZFactory\u0001\u0001": String), ("\u0000\u0000\u0000": String), (30: Int))): izumi.reflect.Tag[org.scalamock.scalamockz.ScalamockZFactory])): zio.Tag[org.scalamock.scalamockz.ScalamockZFactory])).mockContext.generateMockDefaultName("mock").name;
+   *     override def f(x: Int): zio.UIO[String] = $anon.this.mock$f$0.apply(x);
+   *     val mock$f$0: MockFunction1[Int, zio.UIO[String]] = new MockFunction1[Int, zio.UIO[String]](factory$macro$1.get[org.scalamock.scalamockz.ScalamockZFactory]((zio.`package`.Tag.apply[org.scalamock.scalamockz.ScalamockZFactory]((izumi.reflect.Tag.apply[org.scalamock.scalamockz.ScalamockZFactory](classOf[org.scalamock.scalamockz.ScalamockZFactory], izumi.reflect.macrortti.LightTypeTag.parse[Nothing]((-1099772752: Int), ("\u0004\u0000\u0001*org.scalamock.scalamockz.ScalamockZFactory\u0001\u0001": String), ("\u0000\u0000\u0000": String), (30: Int))): izumi.reflect.Tag[org.scalamock.scalamockz.ScalamockZFactory])): zio.Tag[org.scalamock.scalamockz.ScalamockZFactory])).mockContext, scala.Symbol.apply(scala.Predef.augmentString("<%s> %s%s.%s%s").format($anon.this.mock$special$mockName, "Service", "", "f", "")))
+   *   };
+   *   new $anon()
+   * }.asInstanceOf[org.scalamock.scalamockz.ScalamockZSpecSpec.Service]
+   * }}}
+   *
+   * The macro traverses this tree, finds the body of mocked ZIO methods, and wraps them in suspendSucceed.
+   */
+  private def transformAst(c: Context)(tree: c.Tree): c.Tree = {
+    import c.universe._
+
+    object transformer extends Transformer {
+      override def transform(tree: Tree): Tree = tree match {
+        // Matching this part of the generated code:
+        // override def f(x: Int): zio.UIO[String] = $anon.this.mock$f$0.apply(x);
+        case DefDef(mods, name, tparams, vparamss, tpt, rhs) if isZIOType(c)(tpt.tpe) =>
+          DefDef(mods, name, tparams, vparamss, tpt, q"_root_.zio.ZIO.suspendSucceed($rhs)")
+        case _ => super.transform(tree)
+      }
+    }
+
+    transformer.transform(tree)
+  }
+
+  private def isZIOType(c: Context)(tpe: c.Type): Boolean = {
+    tpe != null && tpe.baseClasses.exists(_.fullName == "zio.ZIO")
+  }
+
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/macros/LayeredMockMacros.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/macros/LayeredMockMacros.scala
@@ -1,0 +1,68 @@
+package org.scalamock.scalamockz
+package macros
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+import zio.{Tag, ULayer, URIO}
+
+private[scalamockz] object LayeredMockMacros {
+
+  def mockImpl[A: c.WeakTypeTag](
+      c: blackbox.Context): c.Expr[ULayer[A]] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[A]
+    val factory = TermName(c.freshName("factory"))
+
+    c.Expr[ULayer[A]](
+      q"""
+         _root_.zio.ZLayer.service[_root_.org.scalamock.scalamockz.ScalamockZFactory].flatMap {
+           ($factory: _root_.zio.ZEnvironment[_root_.org.scalamock.scalamockz.ScalamockZFactory]) =>
+             _root_.zio.ZLayer.succeed {
+               _root_.org.scalamock.scalamockz.ScalamockZFactory.mock[$tpe]($factory.get.mockContext)
+             }
+         }
+       """
+    )
+  }
+
+  def stubImpl[A: c.WeakTypeTag](
+      c: blackbox.Context): c.Expr[ULayer[A]] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[A]
+    val factory = TermName(c.freshName("factory"))
+
+    c.Expr[ULayer[A]](
+      q"""
+         _root_.zio.ZLayer.service[_root_.org.scalamock.scalamockz.ScalamockZFactory].flatMap {
+           ($factory: _root_.zio.ZEnvironment[_root_.org.scalamock.scalamockz.ScalamockZFactory]) =>
+             _root_.zio.ZLayer.succeed {
+               _root_.org.scalamock.scalamockz.ScalamockZFactory.stub[$tpe]($factory.get.mockContext)
+             }
+         }
+       """
+    )
+  }
+
+  def mockedImpl[A: c.WeakTypeTag](
+      c: blackbox.Context
+    )(expectations: c.Expr[URIO[A with ScalamockZFactory, Any]]
+    )(tag: c.Expr[Tag[A]]): c.Expr[ULayer[A]] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[A]
+    val factory = TermName(c.freshName("factory"))
+
+    c.Expr[ULayer[A]](
+      q"""
+         _root_.zio.ZLayer.service[_root_.org.scalamock.scalamockz.ScalamockZFactory].flatMap {
+           ($factory: _root_.zio.ZEnvironment[_root_.org.scalamock.scalamockz.ScalamockZFactory]) =>
+             _root_.zio.ZLayer.succeed {
+               _root_.org.scalamock.scalamockz.ScalamockZFactory.mock[$tpe]($factory.get.mockContext)
+             } >+> _root_.zio.ZLayer.fromZIO($expectations)
+         }
+       """
+    )
+  }
+}

--- a/core/shared/src/main/scala/org/scalamock/scalamockz/syntax/MockConvertions.scala
+++ b/core/shared/src/main/scala/org/scalamock/scalamockz/syntax/MockConvertions.scala
@@ -1,0 +1,109 @@
+package org.scalamock.scalamockz.syntax
+
+import org.scalamock.clazz.{Mock, MockImpl}
+import org.scalamock.function.{
+  MockFunction0,
+  MockFunction1,
+  MockFunction10,
+  MockFunction11,
+  MockFunction12,
+  MockFunction13,
+  MockFunction14,
+  MockFunction15,
+  MockFunction16,
+  MockFunction17,
+  MockFunction18,
+  MockFunction19,
+  MockFunction2,
+  MockFunction20,
+  MockFunction21,
+  MockFunction22,
+  MockFunction3,
+  MockFunction4,
+  MockFunction5,
+  MockFunction6,
+  MockFunction7,
+  MockFunction8,
+  MockFunction9,
+  StubFunction0,
+  StubFunction1,
+  StubFunction10,
+  StubFunction11,
+  StubFunction12,
+  StubFunction13,
+  StubFunction14,
+  StubFunction15,
+  StubFunction16,
+  StubFunction17,
+  StubFunction18,
+  StubFunction19,
+  StubFunction2,
+  StubFunction20,
+  StubFunction21,
+  StubFunction22,
+  StubFunction3,
+  StubFunction4,
+  StubFunction5,
+  StubFunction6,
+  StubFunction7,
+  StubFunction8,
+  StubFunction9
+}
+import org.scalamock.util.Defaultable
+import scala.language.experimental.macros
+
+// This is a direct copy of the methods toMockFunctionX and toStubFunctionX from org.scalamock.clazz.Mock
+// The mock and stub methods are not copied
+// The duplication is needed so that you can use the Scalamock DSL in tests, but prevent creating mocks manually
+private[scalamockz] trait MockConvertions {
+
+  // format: off
+  implicit def toMockFunction0[R: Defaultable](f: () => R): MockFunction0[R] = macro MockImpl.toMockFunction0[R]
+  implicit def toMockFunction1[T1, R: Defaultable](f: T1 => R): MockFunction1[T1, R] = macro MockImpl.toMockFunction1[T1, R]
+  implicit def toMockFunction2[T1, T2, R: Defaultable](f: (T1, T2) => R): MockFunction2[T1, T2, R] = macro MockImpl.toMockFunction2[T1, T2, R]
+  implicit def toMockFunction3[T1, T2, T3, R: Defaultable](f: (T1, T2, T3) => R): MockFunction3[T1, T2, T3, R] = macro MockImpl.toMockFunction3[T1, T2, T3, R]
+  implicit def toMockFunction4[T1, T2, T3, T4, R: Defaultable](f: (T1, T2, T3, T4) => R): MockFunction4[T1, T2, T3, T4, R] = macro MockImpl.toMockFunction4[T1, T2, T3, T4, R]
+  implicit def toMockFunction5[T1, T2, T3, T4, T5, R: Defaultable](f: (T1, T2, T3, T4, T5) => R): MockFunction5[T1, T2, T3, T4, T5, R] = macro MockImpl.toMockFunction5[T1, T2, T3, T4, T5, R]
+  implicit def toMockFunction6[T1, T2, T3, T4, T5, T6, R: Defaultable](f: (T1, T2, T3, T4, T5, T6) => R): MockFunction6[T1, T2, T3, T4, T5, T6, R] = macro MockImpl.toMockFunction6[T1, T2, T3, T4, T5, T6, R]
+  implicit def toMockFunction7[T1, T2, T3, T4, T5, T6, T7, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7) => R): MockFunction7[T1, T2, T3, T4, T5, T6, T7, R] = macro MockImpl.toMockFunction7[T1, T2, T3, T4, T5, T6, T7, R]
+  implicit def toMockFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8) => R): MockFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R] = macro MockImpl.toMockFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R]
+  implicit def toMockFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R): MockFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = macro MockImpl.toMockFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
+  implicit def toMockFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R): MockFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = macro MockImpl.toMockFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
+  implicit def toMockFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R): MockFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = macro MockImpl.toMockFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
+  implicit def toMockFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R): MockFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = macro MockImpl.toMockFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
+  implicit def toMockFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R): MockFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = macro MockImpl.toMockFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
+  implicit def toMockFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R): MockFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = macro MockImpl.toMockFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
+  implicit def toMockFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R): MockFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = macro MockImpl.toMockFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
+  implicit def toMockFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R): MockFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = macro MockImpl.toMockFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
+  implicit def toMockFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R): MockFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = macro MockImpl.toMockFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
+  implicit def toMockFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R): MockFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = macro MockImpl.toMockFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
+  implicit def toMockFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R): MockFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = macro MockImpl.toMockFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
+  implicit def toMockFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R): MockFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = macro MockImpl.toMockFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
+  implicit def toMockFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R): MockFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = macro MockImpl.toMockFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
+  implicit def toMockFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R): MockFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = macro MockImpl.toMockFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
+
+  implicit def toStubFunction0[R: Defaultable](f: () => R): StubFunction0[R] = macro MockImpl.toStubFunction0[R]
+  implicit def toStubFunction1[T1,  R: Defaultable](f: T1 => R): StubFunction1[T1, R] = macro MockImpl.toStubFunction1[T1, R]
+  implicit def toStubFunction2[T1, T2, R: Defaultable](f: (T1, T2) => R): StubFunction2[T1, T2, R] = macro MockImpl.toStubFunction2[T1, T2, R]
+  implicit def toStubFunction3[T1, T2, T3, R: Defaultable](f: (T1, T2, T3) => R): StubFunction3[T1, T2, T3, R] = macro MockImpl.toStubFunction3[T1, T2, T3, R]
+  implicit def toStubFunction4[T1, T2, T3, T4, R: Defaultable](f: (T1, T2, T3, T4) => R): StubFunction4[T1, T2, T3, T4, R] = macro MockImpl.toStubFunction4[T1, T2, T3, T4, R]
+  implicit def toStubFunction5[T1, T2, T3, T4, T5, R: Defaultable](f: (T1, T2, T3, T4, T5) => R): StubFunction5[T1, T2, T3, T4, T5, R] = macro MockImpl.toStubFunction5[T1, T2, T3, T4, T5, R]
+  implicit def toStubFunction6[T1, T2, T3, T4, T5, T6, R: Defaultable](f: (T1, T2, T3, T4, T5, T6) => R): StubFunction6[T1, T2, T3, T4, T5, T6, R] = macro MockImpl.toStubFunction6[T1, T2, T3, T4, T5, T6, R]
+  implicit def toStubFunction7[T1, T2, T3, T4, T5, T6, T7, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7) => R): StubFunction7[T1, T2, T3, T4, T5, T6, T7, R] = macro MockImpl.toStubFunction7[T1, T2, T3, T4, T5, T6, T7, R]
+  implicit def toStubFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8) => R): StubFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R] = macro MockImpl.toStubFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R]
+  implicit def toStubFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R): StubFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = macro MockImpl.toStubFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
+  implicit def toStubFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R): StubFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = macro MockImpl.toStubFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
+  implicit def toStubFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R): StubFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = macro MockImpl.toStubFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
+  implicit def toStubFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R): StubFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = macro MockImpl.toStubFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
+  implicit def toStubFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R): StubFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = macro MockImpl.toStubFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
+  implicit def toStubFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R): StubFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = macro MockImpl.toStubFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
+  implicit def toStubFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R): StubFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = macro MockImpl.toStubFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
+  implicit def toStubFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R): StubFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = macro MockImpl.toStubFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
+  implicit def toStubFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R): StubFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = macro MockImpl.toStubFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
+  implicit def toStubFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R): StubFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = macro MockImpl.toStubFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
+  implicit def toStubFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R): StubFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = macro MockImpl.toStubFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
+  implicit def toStubFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R): StubFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = macro MockImpl.toStubFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
+  implicit def toStubFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R): StubFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = macro MockImpl.toStubFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
+  implicit def toStubFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R: Defaultable](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R): StubFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = macro MockImpl.toStubFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
+  //format: on
+}

--- a/core/shared/src/test/scala/org/scalamock/test/scalamockz/ScalamockZSpecSpec.scala
+++ b/core/shared/src/test/scala/org/scalamock/test/scalamockz/ScalamockZSpecSpec.scala
@@ -1,0 +1,141 @@
+package org.scalamock.scalamockz
+
+import org.scalatest.exceptions.TestFailedException
+import zio.test.TestAspect.before
+import zio.test.{assertTrue, TestAspect, TestAspectAtLeastR, TestEnvironment}
+import zio._
+
+object ScalamockZSpecSpec extends ScalamockZSpec {
+
+  trait Service {
+    def f(x: Int): UIO[String]
+  }
+
+  override def spec: MockedSpec =
+    suite("ScalamockZSpec: mocks")(mockTests).provideSome[ScalamockZFactory](mock[Service]) +
+      suite("ScalamockZSpec: stubs")(stubTests).provideSome[ScalamockZFactory](stub[Service])
+
+  private val mockTests = List(
+    test("succeed if function is invoked as expected") {
+      for {
+        _ <- ZIO.serviceWith[Service] { mock =>
+          (mock.f _).expects(42).returnsZIO("-42")
+        }
+        value <- ZIO.serviceWithZIO[Service](_.f(42))
+        _ <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations())
+      } yield assertTrue(value == "-42")
+    },
+    test("when order of invocations is expected, should succeed if two functions are invoked sequentially") {
+      for {
+        _ <- ZIO.serviceWithZIO[Service] { mock =>
+          inSequence {
+            (mock.f _).expects(42).returnsZIO("-42")
+            (mock.f _).expects(43).returnsZIO("1")
+          }
+        }
+        value1 <- ZIO.serviceWithZIO[Service](_.f(42))
+        value2 <- ZIO.serviceWithZIO[Service](_.f(43))
+        _ <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations())
+      } yield assertTrue(value1 == "-42" && value2 == "1")
+    },
+    test("when order of invocations is expected, should fail if second function is invoked before first") {
+      for {
+        _ <- ZIO.serviceWithZIO[Service] { mock =>
+          inSequence {
+            (mock.f _).expects(42).returnsZIO("-42")
+            (mock.f _).expects(43).returnsZIO("1")
+          }
+        }
+        result <- ZIO
+          .serviceWithZIO[Service](_.f(43))
+          .flip
+          .catchSomeDefect { case e: TestFailedException => ZIO.succeed(e) }
+      } yield {
+        val errorMessage = result.getMessage
+        assertTrue(errorMessage.contains("Unexpected call: <mock-1> Service.f(43)"))
+      }
+    },
+    test("when order of invocations is not defined, should succeed if two functions are invoked sequentially") {
+      for {
+        _ <- ZIO.serviceWith[Service] { mock =>
+          (mock.f _).expects(42).returnsZIO("-42")
+          (mock.f _).expects(43).returnsZIO("1")
+        }
+        value1 <- ZIO.serviceWithZIO[Service](_.f(42))
+        value2 <- ZIO.serviceWithZIO[Service](_.f(43))
+        _ <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations())
+      } yield assertTrue(value1 == "-42" && value2 == "1")
+    },
+    test("when order of invocations is not defined, should succeed if second function is invoked before first") {
+      for {
+        _ <- ZIO.serviceWith[Service] { mock =>
+          (mock.f _).expects(42).returnsZIO("-42")
+          (mock.f _).expects(43).returnsZIO("1")
+        }
+        value1 <- ZIO.serviceWithZIO[Service](_.f(43))
+        value2 <- ZIO.serviceWithZIO[Service](_.f(42))
+        _ <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations())
+      } yield assertTrue(value1 == "1" && value2 == "-42")
+    },
+    test("fail if function is invoked with wrong arguments") {
+      for {
+        _ <- ZIO.serviceWith[Service] { mock =>
+          (mock.f _).expects(42).returnsZIO("-42")
+        }
+        result <- ZIO
+          .serviceWithZIO[Service](_.f(41))
+          .flip
+          .catchSomeDefect { case e: TestFailedException => ZIO.succeed(e) }
+      } yield {
+        val errorMessage = result.getMessage
+        assertTrue(
+          errorMessage.contains("<mock-1> Service.f(42) once (never called - UNSATISFIED)") &&
+            !errorMessage.contains("Actual:\n      <mock-1> Service.f(41)")
+        )
+      }
+    },
+    test("fail if function is invoked, but effect is not invoked") {
+      for {
+        _ <- ZIO.serviceWith[Service] { mock =>
+          (mock.f _).expects(42).returnsZIO("-42")
+        }
+        service <- ZIO.service[Service]
+        _ = service.f(42)
+        result <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations()).flip
+      } yield {
+        val errorMessage = result.getMessage
+        assertTrue(errorMessage.contains("<mock-1> Service.f(42) once (never called - UNSATISFIED)"))
+      }
+    }
+  )
+
+  private val stubTests = List(
+    test("fail on non-verified invocation") {
+      for {
+        _ <- ZIO.serviceWith[Service] { stub =>
+          (stub.f _).when(42).returnsZIO("-42")
+          (stub.f _).when(43).returnsZIO("-43")
+        }
+        _ <- ZIO.serviceWithZIO[Service](_.f(42))
+        _ <- ZIO.serviceWith[Service] { stub =>
+          (stub.f _).verify(43)
+        }
+        result <- ZIO.serviceWithZIO[ScalamockZFactory](_.verifyExpectations()).flip
+      } yield {
+        val errorMessage = result.getMessage
+        assertTrue(errorMessage.contains("<stub-1> Service.f(43) once (never called - UNSATISFIED)"))
+      }
+    }
+  )
+
+  // We have to copy-paste aspects from ZIOSpec and ScalamockZSpec
+  // because otherwise, recovery from a verifyExpectations failure in the aspect would not be possible,
+  // and the test couldn't be marked as successful.
+  override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment with ScalamockZFactory]] =
+    Chunk(
+      TestAspect.fibers,
+      TestAspect.timeoutWarning(60.seconds),
+      before(ZIO.serviceWithZIO[ScalamockZFactory](_.initializeExpectations())),
+      TestAspect.fromLayer(ScalamockZFactory.live)
+    )
+}

--- a/core/shared/src/test/scala/org/scalamock/test/scalamockz/ScalamockZSuccessSpec.scala
+++ b/core/shared/src/test/scala/org/scalamock/test/scalamockz/ScalamockZSuccessSpec.scala
@@ -1,0 +1,49 @@
+package somepackage.org.scalamock.scalamockz
+
+import org.scalamock.scalamockz._
+import zio.test.assertTrue
+import zio._
+
+/**
+ * A simple test to verify that mocking from another package (somepackage) works correctly.
+ * We cannot check cases here where tests should fail.
+ * Such cases are tested in [[org.scalamock.scalamockz.ScalamockZSpecSpec]].
+ */
+object ScalamockZSuccessSpec extends ScalamockZSpec {
+
+  trait Service {
+    def f(x: Int): UIO[String]
+  }
+
+  override def spec: MockedSpec =
+    suite("ScalamockZSpec")(
+      test("succeed if function is invoked as expected") {
+        for {
+          _ <- ZIO.serviceWith[Service] { mock =>
+            (mock.f _).expects(42).returnsZIO("-42")
+          }
+          value <- ZIO.serviceWithZIO[Service](_.f(42))
+        } yield assertTrue(value == "-42")
+      }.provideSome[ScalamockZFactory](mock[Service]),
+      test("succeed if not all stub invocation were invoked") {
+        for {
+          _ <- ZIO.serviceWith[Service] { stub =>
+            (stub.f _).when(42).returnsZIO("-42")
+            (stub.f _).when(43).returnsZIO("-43")
+          }
+          value <- ZIO.serviceWithZIO[Service](_.f(42))
+        } yield assertTrue(value == "-42")
+      }.provideSome[ScalamockZFactory](stub[Service]),
+      test("succeed if all verified stub invocations were invoked") {
+        for {
+          _ <- ZIO.serviceWith[Service] { stub =>
+            (stub.f _).when(42).returnsZIO("-42")
+          }
+          value <- ZIO.serviceWithZIO[Service](_.f(42))
+          _ <- ZIO.serviceWith[Service] { stub =>
+            (stub.f _).verify(42)
+          }
+        } yield assertTrue(value == "-42")
+      }.provideSome[ScalamockZFactory](stub[Service])
+    )
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/ScalaMock/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Purpose

This PR demonstrates the integration of the classic Scalamock API with ZIO Test.

Currently, it's a Proof of Concept, and the code does not yet compile in the Scalamock repository. However, I have already used this code as an internal library in our company and have migrated some tests to it.

The main objective of this PR is to decide whether we want to further develop this approach and merge it into the master branch.

If we decide to proceed, the following steps are required to merge the PR:
* [x] Agree on the API.
* [ ] Agree on whether to split this PR into several smaller ones.
* [ ] Fix compilation issues in the Scalamock repository.
* [ ] Add support for Scala 3.
* [ ] Remove the dependency on Scalatest, which was introduced due to code copying.
* [ ] Move documentation from the README.

## Background Context

We use ZIO Test and ZIO Mock extensively in our company but want to transition away from ZIO Mock. Scalamock was selected as an alternative for the following reasons:
- It is a mature and widely-used library with high-quality error reporting.
- It has been ported to Scala 3.

The classic Scalamock API was chosen specifically for several reasons:
- It is easier to migrate from ZIO Mock to the classic Scalamock API rather than the experimental Scalamock API.
- Our developers are already familiar with this API.
- We would like to transition from ZIO Mock to Scalamock first, and then migrate to Scala 3. However, this is not possible with the experimental API, as it does not support Scala 2.

Additionally, a few recurring issues with classic API have been addressed:
- In the classic Scalamock API, it’s too easy to create shared mocks across multiple tests, which can lead to race conditions. In this integration, we handle the creation of mocks through ZLayer, eliminating this issue.
- The classic API does not provide a way to verify whether an effect was actually called. This integration introduces that capability.

I believe these considerations are not only relevant to our team, but could also be helpful for other users. Specifically, those looking to transition from ZIO Mock to Scalamock or use the classic Scalamock API with ZIO Test.

## References

Discussion in the Scala For Anyone community: https://t.me/scala_any/604/25238