### PR TITLE
fix scala 3 implicit conversions for methods without arguments

### DIFF
--- a/cats-effect/shared/src/main/scala-3/org/scalamock/stubs/CatsEffectStubs.scala
+++ b/cats-effect/shared/src/main/scala-3/org/scalamock/stubs/CatsEffectStubs.scala
@@ -3,6 +3,7 @@ package org.scalamock.stubs
 import cats.effect.IO
 import org.scalamock.stubs.{StubbedIOMethod, StubbedIOMethod0}
 import scala.language.implicitConversions
+import scala.util.NotGiven
 
 trait CatsEffectStubs extends StubsBase {
 
@@ -17,7 +18,10 @@ trait CatsEffectStubs extends StubsBase {
 
   final given CatsEffectStubIO = CatsEffectStubIO()
 
-  implicit inline def stubbed[R](inline f: => R): StubbedIOMethod0[R] =
+  implicit inline def stubbed[R](inline f: => R)(using NotGiven[StubbedIOMethod[?, ?]]): StubbedIOMethod0[R] =
+    StubbedIOMethod0[R](stubbed00Impl[R](f))
+
+  implicit inline def stubbed[R](inline f: () => R): StubbedIOMethod0[R] =
     StubbedIOMethod0(stubbed0Impl[R](f))
 
   implicit inline def stubbed[T1, R](inline f: T1 => R): StubbedIOMethod[T1, R] =

--- a/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
+++ b/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
@@ -10,7 +10,7 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
 
   def timesIO: IO[Int] = IO(times)
 
-  def returns(f: => Result): Unit = delegate.returns(f)
+  def returns[RR](f: => RR)(implicit ev: RR <:< Result): Unit = delegate.returns(f)
 
   def times: Int = delegate.times
 

--- a/core/jvm/src/test/scala-2/newapi/UserAuthServiceSpec.scala
+++ b/core/jvm/src/test/scala-2/newapi/UserAuthServiceSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 sealed trait UserStatus
 
@@ -54,6 +55,8 @@ trait UserService {
 
 
 class UserAuthServiceSpec extends AnyFunSpec with Matchers with Stubs with ScalaFutures {
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(1.second, 200.millis)
+
   val unknownUserId = 0
   val user = User(1, UserStatus.Normal)
   val blockedUser = User(2, UserStatus.Blocked)

--- a/core/jvm/src/test/scala-3/newapi/UserAuthServiceSpec.scala
+++ b/core/jvm/src/test/scala-3/newapi/UserAuthServiceSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.*
 
 enum UserStatus:
   case Normal, Blocked
@@ -42,6 +43,8 @@ class UserAuthService(
 
 
 class UserAuthServiceSpec extends AnyFunSpec, Matchers, Stubs, ScalaFutures:
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(1.second, 200.millis)
+
   val unknownUserId = 0
   val user = User(1, UserStatus.Normal)
   val blockedUser = User(2, UserStatus.Blocked)

--- a/core/shared/src/main/scala-2/org/scalamock/stubs/Stubs.scala
+++ b/core/shared/src/main/scala-2/org/scalamock/stubs/Stubs.scala
@@ -22,7 +22,6 @@ package org.scalamock.stubs
 
 import org.scalamock.stubs.internal.StubMakerImpl
 
-import java.util.concurrent.atomic.AtomicReference
 import scala.language.experimental.macros
 import scala.language.implicitConversions
 

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -132,7 +132,7 @@ private[scalamock] class Utils(using val quotes: Quotes):
       case TypeApply(term, types) =>
         searchTermWithMethod(term, argTypes, types)
 
-      case Ident(fun) =>
+      case Ident(fun) if !newApi =>
         report.errorAndAbort(
           s"please declare '$fun' as MockFunctionX or StubFunctionX (e.g val $fun: MockFunction1[X, R] = ... if it has 1 parameter)"
         )

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/Stubs.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/Stubs.scala
@@ -21,6 +21,7 @@
 package org.scalamock.stubs
 
 import scala.language.implicitConversions
+import scala.util.NotGiven
 
 /** Indicates that object of type T was generated */
 opaque type Stub[+T] <: T = T
@@ -46,10 +47,13 @@ trait StubsBase {
 }
 
 trait Stubs extends StubsBase {
-  implicit inline def stubbed[R](inline f: => R): StubbedMethod0[R] =
+  implicit inline def stubbed[R](inline f: => R)(using NotGiven[StubbedMethod[?, ?]]): StubbedMethod0[R] =
+    stubbed00Impl[R](f)
+
+  implicit inline def stubbed[R](inline f: () => R): StubbedMethod0[R] =
     stubbed0Impl[R](f)
 
-  implicit inline def stubbed[T1, R](inline f: T1 => R): StubbedMethod[T1, R] =
+  implicit inline def stubbed[T1, R](inline f: T1 => R)(using NotGiven[<:<[T1 => R, String]]): StubbedMethod[T1, R] =
     stubbed1Impl[T1, R](f)
 
   implicit inline def stubbed[T1, T2, R](inline f: (T1, T2) => R): StubbedMethod[(T1, T2), R] =

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
@@ -10,8 +10,13 @@ inline def stubImpl[T](using
 ): Stub[T] =
   ${ stubMacro[T]('{ createdStubs }, '{ stubUniqueIndexGenerator }) }
 
+
 private
-inline def stubbed0Impl[R](inline f: => R): StubbedMethod0[R] =
+inline def stubbed00Impl[R](inline f: R): StubbedMethod0[R] =
+  ${ stubbed00Macro[R]('{ f }) }
+
+private
+inline def stubbed0Impl[R](inline f: () => R): StubbedMethod0[R] =
   ${ stubbed0Macro[R]('{ f }) }
 
 private
@@ -110,9 +115,15 @@ def stubMacro[T: Type](
 )(using Quotes): Expr[Stub[T]] =
   new internal.StubMaker().newInstance[T](collector, stubUniqueIndexGenerator)
 
+
 @experimental
 private
-def stubbed0Macro[R: Type](f: Expr[R])(using Quotes): Expr[StubbedMethod0[R]] =
+def stubbed00Macro[R: Type](f: Expr[R])(using Quotes): Expr[StubbedMethod0[R]] =
+  new internal.StubMaker().getStubbed00[R](f)
+
+@experimental
+private
+def stubbed0Macro[R: Type](f: Expr[() => R])(using Quotes): Expr[StubbedMethod0[R]] =
   new internal.StubMaker().getStubbed0[R](f)
 
 @experimental

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
@@ -190,7 +190,11 @@ private[stubs] class StubMaker(
 
 
   @experimental
-  def getStubbed0[R: Type](select: Expr[R]): Expr[StubbedMethod0[R]] =
+  def getStubbed00[R: Type](select: Expr[R]): Expr[StubbedMethod0[R]] =
+    searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod0[R]](_.stubValName)
+
+  @experimental
+  def getStubbed0[R: Type](select: Expr[() => R]): Expr[StubbedMethod0[R]] =
     searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod0[R]](_.stubValName)
 
   @experimental

--- a/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
+++ b/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
@@ -62,7 +62,7 @@ trait StubbedMethod0[R] extends StubbedMethod.Order {
    *    foo.foo00() // "abc"
    * }}}
    * */
-  def returns(f: => Result): Unit
+  def returns[RR](f: => RR)(implicit ev: RR <:< Result): Unit
 
   /** Allows to get number of times method was executed.
    *
@@ -301,7 +301,7 @@ object StubbedMethod {
     override def returns(f: Args => Result): Unit =
       resultRef.set(Some(f))
 
-    override def returns(f: => Result): Unit =
+    override def returns[RR](f: => RR)(implicit ev: RR <:< Result): Unit =
       resultRef.set(Some(_ => f))
 
     override def times: Int =

--- a/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
@@ -1,7 +1,5 @@
 package newapi
 
-package newapi
-
 import com.paulbutcher.test.{PolymorphicTrait, SpecializedClass, SpecializedClass2, TestClass, TestTrait}
 import org.scalamock.stubs.Stubs
 import org.scalatest.funspec.AnyFunSpec
@@ -17,6 +15,8 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     m.nullary.returns("a return value")
 
     m.nullary shouldBe "a return value"
+
+    (() => m.nullary).times shouldBe 1
   }
 
   it("cope with infix operators") {
@@ -835,7 +835,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
     val obj = new B {}
 
-    m.methodWithUnionReturnType[B]().returns(obj)
+    (() => m.methodWithUnionReturnType[B]()).returns(obj)
 
     m.methodWithUnionReturnType[B]() shouldBe obj
   }

--- a/zio/shared/src/main/scala-3/org/scalamock/stubs/ZIOStubs.scala
+++ b/zio/shared/src/main/scala-3/org/scalamock/stubs/ZIOStubs.scala
@@ -5,6 +5,8 @@ import org.scalamock.stubs.{StubbedZIOMethod, StubbedZIOMethod0}
 import scala.language.implicitConversions
 import zio.*
 
+import scala.util.NotGiven
+
 trait ZIOStubs extends StubsBase {
   private[scalamock] class ZIOStubIO extends StubIO {
     type F[+A, +B] = IO[A, B]
@@ -14,8 +16,11 @@ trait ZIOStubs extends StubsBase {
     def flatMap[E, EE >: E, T, T2](fa: IO[E, T])(f: T => IO[EE, T2]) = fa.flatMap(f)
   }
   final given ZIOStubIO = ZIOStubIO()
-  
-  implicit inline def stubbed[R](inline f: => R): StubbedZIOMethod0[R] =
+
+  implicit inline def stubbed[R](inline f: => R)(using NotGiven[StubbedZIOMethod[?, ?]]): StubbedZIOMethod0[R] =
+    StubbedZIOMethod0[R](stubbed00Impl[R](f))
+
+  implicit inline def stubbed[T1, R](inline f: () => R): StubbedZIOMethod0[R] =
     StubbedZIOMethod0[R](stubbed0Impl[R](f))
 
   implicit inline def stubbed[T1, R](inline f: T1 => R): StubbedZIOMethod[T1, R] =

--- a/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
+++ b/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
@@ -10,7 +10,7 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
 
   def timesZIO: UIO[Int] = ZIO.succeed(times)
 
-  def returns(f: => Result): Unit = delegate.returns(f)
+  def returns[RR](f: => RR)(implicit ev: RR <:< Result): Unit = delegate.returns(f)
 
   def times: Int = delegate.times
   


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes
Fixes scala 3 implicit conversions for methods without arguments.
Also fixes an issue when `returns` with different value type succeeds because of type inference and union type
