### PR TITLE
deprecate returns, returnsZIO, returnsIO for method without arguments

### DIFF
--- a/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
+++ b/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
@@ -33,7 +33,21 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
    *    } yield ()
    * }}}
    * */
+  @deprecated(
+    "Use `returnsIOWith`, `succeedsWith`, `raisesErrorWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
+  )
   def returnsIO(f: => R): IO[Unit] = IO(returns(f))
+
+  /** Allows to set result for method without arguments. Returns IO.
+   *
+   * {{{
+   *    for {
+   *      _ <- (() => foo.foo00()).returnsIOWith("result")
+   *      _ <- foo.fooIO.returnsIOWith(IO(1))
+   *    } yield ()
+   * }}}
+   * */
+  def returnsIOWith(value: => R): IO[Unit] = returnsIO(value)
 
   /** Allows to set result for method without arguments.
    *
@@ -44,6 +58,14 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
    * */
   def returns(f: => R): Unit = delegate.returns(f)
 
+  /** Allows to set result for method without arguments.
+   *
+   * {{{
+   *    (() => foo.foo00()).returnsWith("result")
+   *    foo.fooIO.returnsWith(IO(1))
+   * }}}
+   * */
+  def returnsWith(f: => R): Unit = delegate.returnsWith(f)
 
   /** Allows to set success for method without arguments. Returns IO.
    *
@@ -54,7 +76,7 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
    * }}}
    * */
   def succeedsWith[RR](value: => RR)(implicit ev: IO[RR] <:< R): IO[Unit] =
-    returnsIO(ev(IO(value)))
+    returnsIOWith(ev(IO(value)))
 
   /** Allows raise error for method without arguments. Returns IO.
    *
@@ -65,7 +87,7 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
    * }}}
    * */
   def raisesErrorWith(ex: => Throwable)(implicit ev: IO[Nothing] <:< R): IO[Unit] =
-    returnsIO(ev(IO.raiseError(ex)))
+    returnsIOWith(ev(IO.raiseError(ex)))
 
   /** Allows to get number of times method was executed.
    *
@@ -151,6 +173,24 @@ class StubbedIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMethod
    *  }}}
    * */
   def returnsIO(f: A => R): IO[Unit] = IO(returns(f))
+
+  /** Allows to set result for method with arguments. Returns IO
+   *
+   *  Scala 3
+   *  {{{
+   *   for
+   *     _ <- foo.bar.returnsIOWith(IO(1))
+   *   yield ()
+   *  }}}
+   *
+   *  Scala 2
+   *  {{{
+   *   for {
+   *     _ <- (foo.bar _).returnsIOWith(IO(1))
+   *   } yield ()
+   *  }}}
+   * */
+  def returnsIOWith(value: => R): IO[Unit] = returnsIO(_ => value)
 
   /** Allows to set success for method with arguments. Returns IO.
    *
@@ -268,6 +308,21 @@ class StubbedIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMethod
    *  }}}
    * */
   def returns(f: A => R): Unit = delegate.returns(f)
+
+
+  /** Allows to set result for method with arguments.
+   *
+   * Scala 3
+   * {{{
+   *   foo.bar.returnsWith(IO(1))
+   * }}}
+   *
+   *  Scala 2
+   *  {{{
+   *   (foo.bar _).returnsWith(IO(1))
+   *   }}}
+   * */
+  def returnsWith(f: => R): Unit = delegate.returnsWith(f)
 
   /** Allows to get number of times method was executed.
    *

--- a/cats-effect/shared/src/test/scala-2/newapi/IOSpec.scala
+++ b/cats-effect/shared/src/test/scala-2/newapi/IOSpec.scala
@@ -34,7 +34,7 @@ class IOSpec extends CatsEffectSuite with CatsEffectStubs {
 
     val foo = stub[Foo]
     val result = for {
-      _ <- foo.zeroArgsIO.returnsIO(IO.none[String])
+      _ <- foo.zeroArgsIO.returnsIOWith(IO.none[String])
       _ <- foo.zeroArgsIO
       _ <- foo.zeroArgsIO
       _ <- foo.zeroArgsIO.timesIO

--- a/cats-effect/shared/src/test/scala-2/newapi/StubbedIOMethodSpec.scala
+++ b/cats-effect/shared/src/test/scala-2/newapi/StubbedIOMethodSpec.scala
@@ -20,7 +20,7 @@ class StubbedIOMethodSpec extends CatsEffectSuite with CatsEffectStubs {
   test("StubbedIOMethod0 - returnsIO should set the return value for a method without arguments") {
     val testStub = stub[TestTrait0]
     for {
-      _ <- testStub.noArgs.returnsIO(IO(42))
+      _ <- testStub.noArgs.returnsIOWith(IO(42))
       result <- testStub.noArgs
     } yield assertEquals(result, 42)
   }
@@ -45,7 +45,7 @@ class StubbedIOMethodSpec extends CatsEffectSuite with CatsEffectStubs {
   test("StubbedIOMethod0 - timesIO should return the number of times a method was called") {
     val testStub = stub[TestTrait0]
     for {
-      _ <- testStub.noArgs.returnsIO(IO(42))
+      _ <- testStub.noArgs.returnsIOWith(IO(42))
       _ <- testStub.noArgs
       _ <- testStub.noArgs
       _ <- testStub.noArgs

--- a/cats-effect/shared/src/test/scala-3/newapi/IOSpec.scala
+++ b/cats-effect/shared/src/test/scala-3/newapi/IOSpec.scala
@@ -31,7 +31,7 @@ class IOSpec extends CatsEffectSuite, CatsEffectStubs:
     given log: CallLog = CallLog()
     val foo = stub[Foo]
     val result = for
-      _ <- foo.zeroArgsIO.returnsIO(IO.none[String])
+      _ <- foo.zeroArgsIO.returnsIOWith(IO.none[String])
       _ <- foo.zeroArgsIO
       _ <- foo.zeroArgsIO
     yield foo.zeroArgsIO.times

--- a/cats-effect/shared/src/test/scala-3/newapi/StubbedIOMethodSpec.scala
+++ b/cats-effect/shared/src/test/scala-3/newapi/StubbedIOMethodSpec.scala
@@ -18,7 +18,7 @@ class StubbedIOMethodSpec extends CatsEffectSuite, CatsEffectStubs:
   test("StubbedIOMethod0 - returnsIO should set the return value for a method without arguments"):
     val testStub = stub[TestTrait0]
     for
-      _ <- testStub.noArgs.returnsIO(IO(42))
+      _ <- testStub.noArgs.returnsIOWith(IO(42))
       result <- testStub.noArgs
     yield assertEquals(result, 42)
 
@@ -40,7 +40,7 @@ class StubbedIOMethodSpec extends CatsEffectSuite, CatsEffectStubs:
   test("StubbedIOMethod0 - timesIO should return the number of times a method was called"):
     val testStub = stub[TestTrait0]
     for
-      _ <- testStub.noArgs.returnsIO(IO(42))
+      _ <- testStub.noArgs.returnsIOWith(IO(42))
       _ <- testStub.noArgs
       _ <- testStub.noArgs
       _ <- testStub.noArgs

--- a/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
+++ b/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
@@ -49,7 +49,12 @@ trait StubbedMethod0[R] extends StubbedMethod.Order {
    *    foo.foo00() // "abc"
    * }}}
    * */
+  @deprecated(
+    "Use `returnsWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
+  )
   def returns(f: => R): Unit
+  
+  def returnsWith(value: => R): Unit
 
   /** Allows to get number of times method was executed.
    *
@@ -120,7 +125,7 @@ trait StubbedMethod[A, R] extends StubbedMethod.Order {
    * }}}
    *
    * */
-  final def returnsWith(value: R): Unit = returns(_ => value)
+  def returnsWith(value: => R): Unit
 
   /** Allows to get number of times method was executed.
    *
@@ -289,8 +294,11 @@ object StubbedMethod {
     override def returns(f: A => R): Unit =
       resultRef.set(Some(f))
 
+    override def returnsWith(value: => R): Unit =
+      resultRef.set(Some(_ => value))
+
     override def returns(f: => R): Unit =
-      resultRef.set(Some(_ => f))
+      returnsWith(f)
 
     override def times: Int =
       callsRef.get().length

--- a/core/shared/src/test/scala-2/newapi/CallLogSpec.scala
+++ b/core/shared/src/test/scala-2/newapi/CallLogSpec.scala
@@ -28,8 +28,8 @@ class CallLogSpec extends AnyFunSpec with Matchers with Stubs {
     (first.foo _).returns(_ => 0)
     (first.foo2 _).returns(_ => 0)
     (second.bar _).returns(_ => "1")
-    (() => second.bar0()).returns("2")
-    (() => second.bar00).returns(3)
+    (() => second.bar0()).returnsWith("2")
+    (() => second.bar00).returnsWith(3)
 
     first.foo(0, 0)
     second.bar("1")

--- a/core/shared/src/test/scala-2/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-2/newapi/NewApiSpec.scala
@@ -40,7 +40,7 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
 
   it("cope with methods without params") {
     val m = stub[TestTrait]
-    (() => m.nullary).returns("a return value")
+    (() => m.nullary).returnsWith("a return value")
 
     m.nullary shouldBe "a return value"
   }
@@ -243,7 +243,7 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
   it("mock an embeddded trait") {
     val m = stub[TestTrait]
     val e = stub[m.Embedded]
-    (() => m.referencesEmbedded()).returns(e)
+    (() => m.referencesEmbedded()).returnsWith(e)
     assertResult(e) {
       m.referencesEmbedded()
     }
@@ -255,8 +255,8 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
     val e = stub[m.Embedded]
     val o = stub[m.ATrait]
     val i = stub[e.ATrait]
-    (() => e.innerTraitProjected()).returns(i)
-    (() => e.outerTraitProjected()).returns(o)
+    (() => e.innerTraitProjected()).returnsWith(i)
+    (() => e.outerTraitProjected()).returnsWith(o)
     assertResult(o) {
       e.outerTraitProjected()
     }
@@ -270,8 +270,8 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
     val e = stub[m.Embedded]
     val o = stub[m.ATrait]
     val i = stub[e.ATrait]
-    (() => e.innerTrait()).returns(i)
-    (() => e.outerTrait()).returns(o)
+    (() => e.innerTrait()).returnsWith(i)
+    (() => e.outerTrait()).returnsWith(o)
     assertResult(o) {
       e.outerTrait()
     }
@@ -819,7 +819,7 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
 
     val obj = new A with B {}
 
-    (() => m.methodWithIntersectionReturnType[B]()).returns(obj)
+    (() => m.methodWithIntersectionReturnType[B]()).returnsWith(obj)
 
     m.methodWithIntersectionReturnType[B]() shouldBe obj
   }
@@ -875,7 +875,7 @@ class NewApiSpec extends AnyFunSpec with Matchers with Stubs {
 
   it("permit mocking classes build with stackable trait pattern") {
     val mockedClass = stub[A]
-    (() => mockedClass.foo()).returns(42)
+    (() => mockedClass.foo()).returnsWith(42)
     (mockedClass.bar _).returns(_ => Seq("a", "b", "c"))
     (mockedClass.baz _).returns {
       case ("A", 1) => 2

--- a/core/shared/src/test/scala-2/newapi/StubbedMethodSpec.scala
+++ b/core/shared/src/test/scala-2/newapi/StubbedMethodSpec.scala
@@ -19,13 +19,13 @@ class StubbedMethodSpec extends AnyFlatSpec with Matchers with Stubs {
 
   "StubbedMethod0" should "set the return value for a method without arguments" in {
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgs).returns(42)
+    (() => testStub.noArgs).returnsWith(42)
     testStub.noArgs should be(42)
   }
 
   it should "track the number of times a method was called" in {
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgs).returns(42)
+    (() => testStub.noArgs).returnsWith(42)
     testStub.noArgs
     testStub.noArgs
     testStub.noArgs
@@ -34,7 +34,7 @@ class StubbedMethodSpec extends AnyFlatSpec with Matchers with Stubs {
 
   it should "work with methods that have parentheses" in {
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgsString()).returns("test")
+    (() => testStub.noArgsString()).returnsWith("test")
     testStub.noArgsString() should be("test")
   }
 

--- a/core/shared/src/test/scala-3/newapi/CallLogSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/CallLogSpec.scala
@@ -33,8 +33,8 @@ class CallLogSpec extends AnyFunSpec with Matchers with Stubs {
     val bar0Stubbed = stubbed(() => second.bar0())
     val bar00Stubbed = stubbed(() => second.bar00)
 
-    bar0Stubbed.returns("2")
-    bar00Stubbed.returns(3)
+    bar0Stubbed.returnsWith("2")
+    bar00Stubbed.returnsWith(3)
 
     first.foo(0, 0)
     second.bar("1")

--- a/core/shared/src/test/scala-3/newapi/CallLogStringSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/CallLogStringSpec.scala
@@ -25,8 +25,8 @@ class CallLogStringSpec extends AnyFunSpec, Matchers, Stubs:
     first.foo.returns(_ => 0)
     first.foo2.returns(_ => 0)
     second.bar.returns(_ => "1")
-    (() => second.bar0()).returns("2")
-    (() => second.bar00).returns(3)
+    (() => second.bar0()).returnsWith("2")
+    (() => second.bar00).returnsWith(3)
 
     first.foo(0, 0)
     second.bar("1")

--- a/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/NewApiSpec.scala
@@ -44,7 +44,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
   it("cope with methods without params") {
     val m = stub[TestTrait]
-    (() => m.nullary).returns("a return value")
+    (() => m.nullary).returnsWith("a return value")
 
     m.nullary shouldBe "a return value"
 
@@ -236,7 +236,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
   it("mock an embeddded trait") {
     val m = stub[TestTrait]
     val e = stub[m.Embedded]
-    (() => m.referencesEmbedded()).returns(e)
+    (() => m.referencesEmbedded()).returnsWith(e)
     assertResult(e) {
       m.referencesEmbedded()
     }
@@ -248,8 +248,8 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     val e = stub[m.Embedded]
     val o = stub[m.ATrait]
     val i = stub[e.ATrait]
-    (() => e.innerTraitProjected()).returns(i)
-    (() => e.outerTraitProjected()).returns(o)
+    (() => e.innerTraitProjected()).returnsWith(i)
+    (() => e.outerTraitProjected()).returnsWith(o)
     assertResult(o) {
       e.outerTraitProjected()
     }
@@ -263,8 +263,8 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
     val e = stub[m.Embedded]
     val o = stub[m.ATrait]
     val i = stub[e.ATrait]
-    (() => e.innerTrait()).returns(i)
-    (() => e.outerTrait()).returns(o)
+    (() => e.innerTrait()).returnsWith(i)
+    (() => e.outerTrait()).returnsWith(o)
     assertResult(o) {
       e.outerTrait()
     }
@@ -867,7 +867,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
     val obj = new B {}
 
-    (() => m.methodWithUnionReturnType[B]()).returns(obj)
+    (() => m.methodWithUnionReturnType[B]()).returnsWith(obj)
 
     m.methodWithUnionReturnType[B]() shouldBe obj
   }
@@ -887,7 +887,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
     val obj = new A with B {}
 
-    (() => m.methodWithIntersectionReturnType[B]()).returns(obj)
+    (() => m.methodWithIntersectionReturnType[B]()).returnsWith(obj)
 
     m.methodWithIntersectionReturnType[B]() shouldBe obj
   }
@@ -981,7 +981,7 @@ class NewApiSpec extends AnyFunSpec, Matchers, Stubs:
 
   it("permit mocking classes build with stackable trait pattern") {
     val mockedClass = stub[A]
-    (() => mockedClass.foo()).returns(42)
+    (() => mockedClass.foo()).returnsWith(42)
     (mockedClass.bar).returns(_ => Seq("a", "b", "c"))
     (mockedClass.baz).returns:
       case ("A", 1) => 2

--- a/core/shared/src/test/scala-3/newapi/StubbedMethodSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/StubbedMethodSpec.scala
@@ -17,12 +17,12 @@ class StubbedMethodSpec extends AnyFlatSpec with Matchers with Stubs:
 
   "StubbedMethod0" should "set the return value for a method without arguments" in:
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgs).returns(42)
+    (() => testStub.noArgs).returnsWith(42)
     testStub.noArgs should be(42)
 
   it should "track the number of times a method was called" in:
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgs).returns(42)
+    (() => testStub.noArgs).returnsWith(42)
     testStub.noArgs
     testStub.noArgs
     testStub.noArgs
@@ -30,7 +30,7 @@ class StubbedMethodSpec extends AnyFlatSpec with Matchers with Stubs:
 
   it should "work with methods that have parentheses" in:
     val testStub = stub[TestTrait0]
-    (() => testStub.noArgsString()).returns("test")
+    (() => testStub.noArgsString()).returnsWith("test")
     testStub.noArgsString() should be("test")
 
   "StubbedMethod" should "set the return value for a method with arguments" in:

--- a/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
+++ b/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
@@ -33,7 +33,21 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
    *    } yield ()
    * }}}
    * */
+  @deprecated(
+    "Use `returnsZIOWith`, `succeedsWith`, `failsWith`, `diesWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
+  )
   def returnsZIO(f: => R): UIO[Unit] = ZIO.succeed(returns(f))
+
+  /** Allows to set result for method without arguments. Returns ZIO.
+   *
+   * {{{
+   *    for {
+   *      _ <- (() => foo.foo00()).returnsZIOWith("result")
+   *      _ <- foo.fooIO.returnsZIOWith(ZIO.succeed(1))
+   *    } yield ()
+   * }}}
+   * */
+  def returnsZIOWith(value: => R): UIO[Unit] = returnsZIO(value)
 
   /** Allows to set success for method without arguments. Returns ZIO.
    *
@@ -45,7 +59,7 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
    * }}}
    * */
   def succeedsWith[RR](f: => RR)(implicit ev: IO[Nothing, RR] <:< R): UIO[Unit] =
-    returnsZIO(ev(ZIO.succeed(f)))
+    returnsZIOWith(ev(ZIO.succeed(f)))
 
   /** Allows set fail result for method without arguments. Returns ZIO.
    *
@@ -57,7 +71,7 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
    * }}}
    * */
   def failsWith[RR](f: => RR)(implicit ev: IO[RR, Nothing] <:< R): UIO[Unit] =
-    returnsZIO(ev(ZIO.fail(f)))
+    returnsZIOWith(ev(ZIO.fail(f)))
 
   /** Allows set die result for method without arguments. Returns ZIO.
    *
@@ -69,7 +83,7 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
    * }}}
    * */
   def diesWith(f: => Throwable)(implicit ev: UIO[Nothing] <:< R): UIO[Unit] =
-    ZIO.succeed(returns(ev(Exit.die(f))))
+    returnsZIOWith(ev(Exit.die(f)))
 
   /** Allows to get number of times method was executed. Returns ZIO
    *
@@ -90,7 +104,19 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
    *   foo.fooIO.returns(ZIO.succeed(1))
    * }}}
    * */
+  @deprecated(
+    "Use `returnsWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
+  )
   def returns(f: => R): Unit = delegate.returns(f)
+
+  /** Allows to set result for method without arguments.
+   *
+   * {{{
+   *   (() => foo.foo00()).returnsWith("result")
+   *   foo.fooIO.returnsWith(ZIO.succeed(1))
+   * }}}
+   * */
+  def returnsWith(value: => R) = delegate.returnsWith(value)
 
   /** Allows to get number of times method was executed.
    *
@@ -167,6 +193,24 @@ class StubbedZIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMetho
    *  }}}
    * */
   def returnsZIO(f: A => R): UIO[Unit] = ZIO.succeed(returns(f))
+
+  /** Allows to set result for method with arguments. Returns ZIO
+   *
+   * Scala 3
+   * {{{
+   *   for
+   *     _ <- foo.bar.returnsZIOWith(ZIO.succeed(1))
+   *   yield ()
+   *   }}}
+   *
+   *  Scala 2
+   *  {{{
+   *   for {
+   *     _ <- (foo.bar _).returnsZIOWith(ZIO.succeed(1))
+   *   } yield ()
+   * }}}
+   * */
+  def returnsZIOWith(value: => R): UIO[Unit] = returnsZIO(_ => value)
 
   /** Allows to set success for method with arguments. Returns ZIO
    *
@@ -308,6 +352,19 @@ class StubbedZIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMetho
    *  }}}
    * */
   def returns(f: A => R): Unit = delegate.returns(f)
+
+  /** Allows to set result for method without arguments.
+   *
+   * Scala 3
+   * {{{
+   *   foo.bar.returnsWith(ZIO.succeed(1))
+   * }}}
+   * Scala 2
+   * {{{
+   *   (foo.bar _).returnsWith(ZIO.succeed(1))
+   * }}}
+   * */
+  def returnsWith(value: => R) = delegate.returnsWith(value)
 
   /** Allows to get number of times method was executed.
    *

--- a/zio/shared/src/test/scala-2/newapi/StubbedZIOMethodSpec.scala
+++ b/zio/shared/src/test/scala-2/newapi/StubbedZIOMethodSpec.scala
@@ -24,7 +24,7 @@ object StubbedZIOMethodSpec extends ZIOSpecDefault with ZIOStubs {
         test("returnsZIO should set the return value for a method without arguments") {
           val testStub = stub[TestTrait0]
           for {
-            _ <- testStub.noArgs.returnsZIO(ZIO.succeed(42))
+            _ <- testStub.noArgs.returnsZIOWith(ZIO.succeed(42))
             result <- testStub.noArgs
           } yield assertTrue(result == 42)
         },
@@ -59,7 +59,7 @@ object StubbedZIOMethodSpec extends ZIOSpecDefault with ZIOStubs {
         test("timesZIO should return the number of times a method was called") {
           val testStub = stub[TestTrait0]
           for {
-            _ <- testStub.noArgs.returnsZIO(ZIO.succeed(42))
+            _ <- testStub.noArgs.returnsZIOWith(ZIO.succeed(42))
             _ <- testStub.noArgs
             _ <- testStub.noArgs
             _ <- testStub.noArgs

--- a/zio/shared/src/test/scala-2/newapi/ZIOSpec.scala
+++ b/zio/shared/src/test/scala-2/newapi/ZIOSpec.scala
@@ -54,7 +54,7 @@ object ZIOSpec extends ZIOSpecDefault with ZIOStubs {
     suite("check expectations with zio")(
       test("zero args") {
         for {
-          _ <- foo.zeroArgsTask.returnsZIO(ZIO.none)
+          _ <- foo.zeroArgsTask.returnsZIOWith(ZIO.none)
           _ <- foo.zeroArgsTask.repeatN(10)
           times = foo.zeroArgsTask.times
         } yield assertTrue(times == 11)

--- a/zio/shared/src/test/scala-3/newapi/StubbedZIOMethodSpec.scala
+++ b/zio/shared/src/test/scala-3/newapi/StubbedZIOMethodSpec.scala
@@ -23,7 +23,7 @@ object StubbedZIOMethodSpec extends ZIOSpecDefault, ZIOStubs:
         test("returnsZIO should set the return value for a method without arguments"):
           val testStub = stub[TestTrait0]
           for
-            _ <- testStub.noArgs.returnsZIO(ZIO.succeed(42))
+            _ <- testStub.noArgs.returnsZIOWith(ZIO.succeed(42))
             result <- testStub.noArgs
           yield assertTrue(result == 42)
         ,
@@ -56,7 +56,7 @@ object StubbedZIOMethodSpec extends ZIOSpecDefault, ZIOStubs:
         test("timesZIO should return the number of times a method was called"):
           val testStub = stub[TestTrait0]
           for
-            _ <- testStub.noArgs.returnsZIO(ZIO.succeed(42))
+            _ <- testStub.noArgs.returnsZIOWith(ZIO.succeed(42))
             _ <- testStub.noArgs
             _ <- testStub.noArgs
             _ <- testStub.noArgs

--- a/zio/shared/src/test/scala-3/newapi/ZIOSpec.scala
+++ b/zio/shared/src/test/scala-3/newapi/ZIOSpec.scala
@@ -53,7 +53,7 @@ object ZIOSpec extends ZIOSpecDefault, ZIOStubs:
     suite("check expectations with zio")(
       test("zero args"):
         for
-          _ <- foo.zeroArgsTask.returnsZIO(ZIO.none)
+          _ <- foo.zeroArgsTask.returnsZIOWith(ZIO.none)
           _ <- foo.zeroArgsTask.repeatN(10)
         yield assertTrue(foo.zeroArgsTask.times == 11),
       test("two args and cleanup"):


### PR DESCRIPTION


# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
