### PR TITLE
replace StubbedMethod0[R] with StubbedMethod[Unit, R]

### DIFF
--- a/cats-effect/shared/src/main/scala-2/org/scalamock/stubs/CatsEffectStubs.scala
+++ b/cats-effect/shared/src/main/scala-2/org/scalamock/stubs/CatsEffectStubs.scala
@@ -18,10 +18,10 @@ trait CatsEffectStubs extends StubsBase {
 
   final implicit val stubIO: CatsEffectStubIO = new CatsEffectStubIO()
 
-  implicit def stubbed[R](f: => R)(implicit ev: R <:< IO[_]): StubbedIOMethod0[R] =
+  implicit def stubbed[R](f: => R)(implicit ev: R <:< IO[_]): StubbedIOMethod[Unit, R] =
     macro CatsStubMakerImpl.toStubbedMethod00[R]
 
-  implicit def stubbed[R](f: () => R): StubbedIOMethod0[R] =
+  implicit def stubbed[R](f: () => R): StubbedIOMethod[Unit, R] =
     macro CatsStubMakerImpl.toStubbedMethod0[R]
 
   implicit def stubbed[T1, R](f: T1 => R): StubbedIOMethod[T1, R] =

--- a/cats-effect/shared/src/main/scala-2/org/scalamock/stubs/internal/CatsStubMakerImpl.scala
+++ b/cats-effect/shared/src/main/scala-2/org/scalamock/stubs/internal/CatsStubMakerImpl.scala
@@ -1,20 +1,20 @@
 package org.scalamock.stubs.internal
 
-import org.scalamock.stubs.{StubbedIOMethod0, StubbedIOMethod, StubbedMethod, StubbedMethod0}
+import org.scalamock.stubs.{StubbedIOMethod, StubbedMethod}
 import org.scalamock.util.MacroAdapter.Context
 
 private[scalamock]
 object CatsStubMakerImpl {
-  def toStubbedMethod00[R: c.WeakTypeTag](c: Context)(f: c.Expr[R])(ev: c.Expr[Any]): c.Expr[StubbedIOMethod0[R]] = {
+  def toStubbedMethod00[R: c.WeakTypeTag](c: Context)(f: c.Expr[R])(ev: c.Expr[Any]): c.Expr[StubbedIOMethod[Unit, R]] = {
     import c.universe._
-    val sm = StubbedMethodFinder.find[StubbedMethod0[R]](c)(f, List(c.weakTypeOf[Unit]))
-    c.Expr[StubbedIOMethod0[R]](q"new _root_.org.scalamock.stubs.StubbedIOMethod0($sm)")
+    val sm = StubbedMethodFinder.find[StubbedMethod[Unit, R]](c)(f, List(c.weakTypeOf[Unit]))
+    c.Expr[StubbedIOMethod[Unit, R]](q"new _root_.org.scalamock.stubs.StubbedIOMethod($sm)")
   }
 
-  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedIOMethod0[R]] = {
+  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedIOMethod[Unit, R]] = {
     import c.universe._
-    val sm = StubbedMethodFinder.find[StubbedMethod0[R]](c)(f, List(c.weakTypeOf[Unit]))
-    c.Expr[StubbedIOMethod0[R]](q"new _root_.org.scalamock.stubs.StubbedIOMethod0($sm)")
+    val sm = StubbedMethodFinder.find[StubbedMethod[Unit, R]](c)(f, List(c.weakTypeOf[Unit]))
+    c.Expr[StubbedIOMethod[Unit, R]](q"new _root_.org.scalamock.stubs.StubbedIOMethod($sm)")
   }
 
   def toStubbedMethod1[T1: c.WeakTypeTag, R: c.WeakTypeTag](c: Context)(f: c.Expr[T1 => R]): c.Expr[StubbedIOMethod[T1, R]] = {

--- a/cats-effect/shared/src/main/scala-3/org/scalamock/stubs/CatsEffectStubs.scala
+++ b/cats-effect/shared/src/main/scala-3/org/scalamock/stubs/CatsEffectStubs.scala
@@ -1,7 +1,7 @@
 package org.scalamock.stubs
 
 import cats.effect.IO
-import org.scalamock.stubs.{StubbedIOMethod, StubbedIOMethod0}
+import org.scalamock.stubs.StubbedIOMethod
 import scala.language.implicitConversions
 import scala.util.NotGiven
 import scala.concurrent.Future
@@ -19,11 +19,11 @@ trait CatsEffectStubs extends StubsBase {
 
   final given CatsEffectStubIO = CatsEffectStubIO()
 
-  implicit inline def stubbed[R](inline f: => R)(using R <:< IO[?]): StubbedIOMethod0[R] =
-    StubbedIOMethod0[R](stubbed00Impl[R](f))
+  implicit inline def stubbed[R](inline f: => R)(using R <:< IO[?]): StubbedIOMethod[Unit, R] =
+    StubbedIOMethod(stubbed00Impl[R](f))
 
-  implicit inline def stubbed[R](inline f: () => R)(using R =:= R): StubbedIOMethod0[R] =
-    StubbedIOMethod0(stubbed0Impl[R](f))
+  implicit inline def stubbed[R](inline f: () => R)(using R =:= R): StubbedIOMethod[Unit, R] =
+    StubbedIOMethod(stubbed0Impl[R](f))
 
   implicit inline def stubbed[T1, R](inline f: T1 => R)(using (T1, R) =:= (T1, R)): StubbedIOMethod[T1, R] =
     StubbedIOMethod(stubbed1Impl[T1, R](f))

--- a/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
+++ b/cats-effect/shared/src/main/scala/org/scalamock/stubs/StubbedIOMethod.scala
@@ -3,140 +3,12 @@ package org.scalamock.stubs
 import cats.effect.IO
 
 /**
- * Representation of stubbed method without arguments.
- *
- * [[CatsEffectStubs]] interface provides implicit conversion from selected method to StubbedMethodIO0.
- * {{{
- *   trait Foo:
- *     def foo00(): String
- *     def fooIO: IO[Int]
- *
- *   val foo = stub[Foo]
- * }}}
- *
- * The default way of getting stub for such method - convert it to a function () => R.
- * 
- * Exclusively for IO - you can omit converting it to function
- *
- * {{{
- *   val foo00Stubbed: StubbedMethod0[String] = () => foo.foo00()
- *   val fooIOStubbed: StubbedMethod0[IO[Int]] = foo.fooIO
- * }}}
- * */
-class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R] {
-  /** Allows to set result for method without arguments. Returns IO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).returnsIO("result")
-   *      _ <- foo.fooIO.returnsIO(IO(1))
-   *    } yield ()
-   * }}}
-   * */
-  @deprecated(
-    "Use `returnsIOWith`, `succeedsWith`, `raisesErrorWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
-  )
-  def returnsIO(f: => R): IO[Unit] = IO(returns(f))
-
-  /** Allows to set result for method without arguments. Returns IO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).returnsIOWith("result")
-   *      _ <- foo.fooIO.returnsIOWith(IO(1))
-   *    } yield ()
-   * }}}
-   * */
-  def returnsIOWith(value: => R): IO[Unit] = returnsIO(value)
-
-  /** Allows to set result for method without arguments.
-   *
-   * {{{
-   *    (() => foo.foo00()).returns("result")
-   *    foo.fooIO.returns(IO(1))
-   * }}}
-   * */
-  def returns(f: => R): Unit = delegate.returns(f)
-
-  /** Allows to set result for method without arguments.
-   *
-   * {{{
-   *    (() => foo.foo00()).returnsWith("result")
-   *    foo.fooIO.returnsWith(IO(1))
-   * }}}
-   * */
-  def returnsWith(f: => R): Unit = delegate.returnsWith(f)
-
-  /** Allows to set success for method without arguments. Returns IO.
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.succeedsWith(1)
-   *    } yield ()
-   * }}}
-   * */
-  def succeedsWith[RR](value: => RR)(implicit ev: IO[RR] <:< R): IO[Unit] =
-    returnsIOWith(ev(IO(value)))
-
-  /** Allows raise error for method without arguments. Returns IO.
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.failsWith(1)
-   *    } yield ()
-   * }}}
-   * */
-  def raisesErrorWith(ex: => Throwable)(implicit ev: IO[Nothing] <:< R): IO[Unit] =
-    returnsIOWith(ev(IO.raiseError(ex)))
-
-  /** Allows to get number of times method was executed.
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.returnsIO(IO(1))
-   *      _ <- foo.fooIO
-   *      _ <- foo.fooIO
-   *    } yield foo.fooIO.times == 2 // true
-   * }}}
-   * */
-  def times: Int = delegate.times
-
-  /** Allows to get number of times method was executed. Returns IO.
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.returnsIO(IO(1))
-   *      _ <- foo.fooIO
-   *      _ <- foo.fooIO
-   *      fooIOTimes <- foo.fooIO.timesIO
-   *    } yield fooIOTimes == 2 // true
-   * }}}
-   * */
-  def timesIO: IO[Int] = IO(times)
-
-
-  /** Returns true if this method was called before other method. */
-  def isBefore(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
-    delegate.isBefore(other)
-    
-  /** Returns true if this method was called after other method. */
-  def isAfter(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
-    delegate.isAfter(other)
-
-  /** Returns string representation of method.
-   *  Representation currently depends on scala version.
-   */
-  def asString: String = delegate.asString
-
-  override def toString: String = asString
-}
-
-/**
- * Representation of stubbed method with arguments.
+ * Representation of stubbed method
  *
  * [[CatsEffectStubs]] interface provides implicit conversion from selected method to StubbedMethodIO.
  * {{{
  *   trait Foo:
+ *     def foo0: IO[String]
  *     def foo(x: Int): IO[String]
  *     def bar(x: Int, y: String): IO[Int]
  *
@@ -145,12 +17,14 @@ class StubbedIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R]
  *
  * Scala 3
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, IO[String]] = foo.foo0
  *   val fooStubbed: StubbedMethod[Int, IO[String]] = foo.foo
  *   val barStubbed: StubbedMethod[(Int, String), IO[Int]] = foo.bar
  * }}}
  *
  * Scala 2
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, IO[String]] = foo.foo0
  *   val fooStubbed: StubbedMethod[Int, IO[String]] = foo.foo _
  *   val barStubbed: StubbedMethod[(Int, String), IO[Int]] = foo.bar _
  * }}}
@@ -369,11 +243,11 @@ class StubbedIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMethod
   def calls: List[A] = delegate.calls
 
   /** Returns true if this method was called before other method. */
-  def isBefore(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
+  def isBefore(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean =
     delegate.isBefore(other)
 
   /** Returns true if this method was called after other method. */
-  def isAfter(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
+  def isAfter(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean =
     delegate.isAfter(other)
 
   /** Returns string representation of method.

--- a/core/shared/src/main/scala-2/org/scalamock/stubs/Stubs.scala
+++ b/core/shared/src/main/scala-2/org/scalamock/stubs/Stubs.scala
@@ -44,7 +44,7 @@ trait StubsBase {
 }
 
 trait Stubs extends StubsBase {
-  implicit def stubbed[R](f: () => R): StubbedMethod0[R] =
+  implicit def stubbed[R](f: () => R): StubbedMethod[Unit, R] =
     macro StubMakerImpl.toStubbedMethod0[R]
 
   implicit def stubbed[T1, R](f: T1 => R): StubbedMethod[T1, R] =

--- a/core/shared/src/main/scala-2/org/scalamock/stubs/internal/StubMakerImpl.scala
+++ b/core/shared/src/main/scala-2/org/scalamock/stubs/internal/StubMakerImpl.scala
@@ -22,7 +22,7 @@ package org.scalamock.stubs.internal
 
 import org.scalamock.context.MockContext
 import org.scalamock.util.MacroAdapter.Context
-import org.scalamock.stubs.{StubbedMethod, StubbedMethod0, Stub}
+import org.scalamock.stubs.{StubbedMethod, Stub}
 
 private[scalamock]
 object StubMakerImpl {
@@ -35,8 +35,8 @@ object StubMakerImpl {
     new maker.StubMakerInner[T](createdStubs, stubUniqueIndexGenerator).make
   }
 
-  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedMethod0[R]] =
-    StubbedMethodFinder.find[StubbedMethod0[R]](c)(f, List(c.weakTypeOf[Unit]))
+  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedMethod[Unit, R]] =
+    StubbedMethodFinder.find[StubbedMethod[Unit, R]](c)(f, List(c.weakTypeOf[Unit]))
   
   def toStubbedMethod1[T1: c.WeakTypeTag, R: c.WeakTypeTag](c: Context)(f: c.Expr[T1 => R]): c.Expr[StubbedMethod[T1, R]] =
     StubbedMethodFinder.find[StubbedMethod[T1, R]](c)(f, List(c.weakTypeOf[T1]))

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/Stubs.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/Stubs.scala
@@ -46,10 +46,10 @@ trait StubsBase {
 
 trait Stubs extends StubsBase {
 
-  implicit inline def stubbed[R](inline f: => R)(using R <:< Future[?]): StubbedMethod0[R] =
+  implicit inline def stubbed[R](inline f: => R)(using R <:< Future[?]): StubbedMethod[Unit, R] =
     stubbed00Impl[R](f)
 
-  implicit inline def stubbed[R](inline f: () => R)(using R =:= R): StubbedMethod0[R] =
+  implicit inline def stubbed[R](inline f: () => R)(using R =:= R): StubbedMethod[Unit, R] =
     stubbed0Impl[R](f)
 
   implicit inline def stubbed[T1, R](inline f: T1 => R)(using (T1, R) =:= (T1, R)): StubbedMethod[T1, R] =

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/StubsMacro.scala
@@ -12,11 +12,11 @@ inline def stubImpl[T](using
 
 
 private
-inline def stubbed00Impl[R](inline f: R): StubbedMethod0[R] =
+inline def stubbed00Impl[R](inline f: R): StubbedMethod[Unit, R] =
   ${ stubbed00Macro[R]('{ f }) }
 
 private
-inline def stubbed0Impl[R](inline f: () => R): StubbedMethod0[R] =
+inline def stubbed0Impl[R](inline f: () => R): StubbedMethod[Unit, R] =
   ${ stubbed0Macro[R]('{ f }) }
 
 private
@@ -118,12 +118,12 @@ def stubMacro[T: Type](
 
 @experimental
 private
-def stubbed00Macro[R: Type](f: Expr[R])(using Quotes): Expr[StubbedMethod0[R]] =
+def stubbed00Macro[R: Type](f: Expr[R])(using Quotes): Expr[StubbedMethod[Unit, R]] =
   new internal.StubMaker().getStubbed00[R](f)
 
 @experimental
 private
-def stubbed0Macro[R: Type](f: Expr[() => R])(using Quotes): Expr[StubbedMethod0[R]] =
+def stubbed0Macro[R: Type](f: Expr[() => R])(using Quotes): Expr[StubbedMethod[Unit, R]] =
   new internal.StubMaker().getStubbed0[R](f)
 
 @experimental

--- a/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/stubs/internal/StubMaker.scala
@@ -21,7 +21,7 @@
 package org.scalamock.stubs.internal
 
 import org.scalamock.clazz.Utils
-import org.scalamock.stubs.{CallLog, Stub, StubIO, StubbedMethod, StubbedMethod0}
+import org.scalamock.stubs.{CallLog, Stub, StubIO, StubbedMethod}
 
 import scala.annotation.{experimental, tailrec}
 import scala.collection.mutable
@@ -190,12 +190,12 @@ private[stubs] class StubMaker(
 
 
   @experimental
-  def getStubbed00[R: Type](select: Expr[R]): Expr[StubbedMethod0[R]] =
-    searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod0[R]](_.stubValName)
+  def getStubbed00[R: Type](select: Expr[R]): Expr[StubbedMethod[Unit, R]] =
+    searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod[Unit, R]](_.stubValName)
 
   @experimental
-  def getStubbed0[R: Type](select: Expr[() => R]): Expr[StubbedMethod0[R]] =
-    searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod0[R]](_.stubValName)
+  def getStubbed0[R: Type](select: Expr[() => R]): Expr[StubbedMethod[Unit, R]] =
+    searchTermWithMethod(select.asTerm, Nil).selectReflect[StubbedMethod[Unit, R]](_.stubValName)
 
   @experimental
   def getStubbed[Args: Type, R: Type](select: Expr[Any]): Expr[StubbedMethod[Args, R]] =

--- a/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
+++ b/core/shared/src/main/scala/org/scalamock/stubs/StubbedMethod.scala
@@ -23,58 +23,12 @@ package org.scalamock.stubs
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Representation of stubbed method without arguments.
- *
- * [[Stubs]] interface provides implicit conversion from selected method to StubbedMethod0
- *
- * You need to explicitly convert it to a function () => R
- * 
- * {{{
- *   trait Foo:
- *     def foo0: Int
- *     def foo00(): String
- *
- *   val foo = stub[Foo]
- *
- *   val foo0Stubbed: StubbedMethod0[Int] = () => foo.foo0
- *   val foo00Stubbed: StubbedMethod0[String] = () => foo.foo00()
- * }}}
- * */
-trait StubbedMethod0[R] extends StubbedMethod.Order {
-
-  /** Allows to set result for method without arguments.
-   *
-   * {{{
-   *    (() => foo.foo00()).returns("abc")
-   *    foo.foo00() // "abc"
-   * }}}
-   * */
-  @deprecated(
-    "Use `returnsWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
-  )
-  def returns(f: => R): Unit
-  
-  def returnsWith(value: => R): Unit
-
-  /** Allows to get number of times method was executed.
-   *
-   *  {{{
-   *   (() => foo.foo0).returns(5)
-   *   foo.foo0
-   *   foo.foo0
-   *
-   *   (() => foo.foo0).times // 2
-   *  }}}
-   * */
-  def times: Int
-}
-
-/**
  * Representation of stubbed method with arguments.
  *
  * [[Stubs]] interface provides implicit conversions from selected method to StubbedMethod.
  * {{{
  *   trait Foo:
+ *     def foo0: Int
  *     def foo(x: Int): Int
  *     def fooBar(bar: Boolean, baz: String): String
  *
@@ -83,17 +37,19 @@ trait StubbedMethod0[R] extends StubbedMethod.Order {
  *
  * Scala 2
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, Int] = () => foo.foo0
  *   val fooStubbed: StubbedMethod[Int, Int] = foo.foo _
  *   val fooBarStubbed: StubbedMethod[(Boolean, String), String] = foo.fooBar _
  * }}}
  *
  * Scala 3
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, Int] = () => foo.foo0
  *   val fooStubbed: StubbedMethod[Int, Int] = foo.foo
  *   val fooBarStubbed: StubbedMethod[(Boolean, String), String] = foo.fooBar
  * }}}
  * */
-trait StubbedMethod[A, R] extends StubbedMethod.Order {
+trait StubbedMethod[A, R] {
   /** Allows to set result for method with arguments.
    *
    *  Scala 3
@@ -189,71 +145,67 @@ trait StubbedMethod[A, R] extends StubbedMethod.Order {
    * }}}
    * */
   def calls: List[A]
+
+  /**
+   * Returns true if this method was called before other method.
+   *
+   * Scala 3
+   * {{{
+   *   foo.foo.returns(_ => 5)
+   *   foo.fooBar.returns(_ => "bar")
+   *   foo.foo(1)
+   *   foo.fooBar(true, "bar")
+   *
+   *   foo.foo.isBefore(foo.fooBar) // true
+   *   }}}
+   *  Scala 2
+   *  {{{
+   *    (foo.foo _).returns(_ => 5)
+   *    (foo.fooBar _).returns(_ => "bar")
+   *    foo.foo(1)
+   *    foo.fooBar(true, "bar")
+   *
+   *   (foo.foo _).isBefore(foo.fooBar _) // true
+   * }}}
+   */
+  def isBefore(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean
+
+  /** Returns true if this method was called after other method.
+   *
+   *  Scala 3
+   *  {{{
+   *   foo.foo.returns(_ => 5)
+   *   foo.fooBar.returns(_ => "bar")
+   *   foo.foo(1)
+   *   foo.fooBar(true, "bar")
+   *
+   *   foo.foo.isAfter(foo.fooBar) // false
+   * }}}
+   *
+   *  Scala 2
+   *  {{{
+   *    (foo.foo _).returns(_ => 5)
+   *    (foo.fooBar _).returns(_ => "bar")
+   *    foo.foo(1)
+   *    foo.fooBar(true, "bar")
+   *
+   *   (foo.foo _).isAfter(foo.fooBar _) // false
+   * }}}
+   * */
+  def isAfter(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean
+
+  /** Returns string representation of method.
+   *  Representation currently depends on scala version.
+   * */
+  def asString: String
 }
 
 object StubbedMethod {
-  /** Allows to verify order of calls. */
-  sealed trait Order {
-    /**
-     * Returns true if this method was called before other method.
-     *
-     *  Scala 3
-     *  {{{
-     *   foo.foo.returns(_ => 5)
-     *   foo.fooBar.returns(_ => "bar")
-     *   foo.foo(1)
-     *   foo.fooBar(true, "bar")
-     *
-     *   foo.foo.isBefore(foo.fooBar) // true
-     *  }}}
-     *  Scala 2
-     *  {{{
-     *    (foo.foo _).returns(_ => 5)
-     *    (foo.fooBar _).returns(_ => "bar")
-     *    foo.foo(1)
-     *    foo.fooBar(true, "bar")
-     *
-     *   (foo.foo _).isBefore(foo.fooBar _) // true
-     *  }}}
-     */
-    def isBefore(other: Order)(implicit callLog: CallLog): Boolean
-
-    /** Returns true if this method was called after other method.
-     *
-     *  Scala 3
-     *  {{{
-     *   foo.foo.returns(_ => 5)
-     *   foo.fooBar.returns(_ => "bar")
-     *   foo.foo(1)
-     *   foo.fooBar(true, "bar")
-     *
-     *   foo.foo.isAfter(foo.fooBar) // false
-     *  }}}
-     *
-     *  Scala 2
-     *  {{{
-     *    (foo.foo _).returns(_ => 5)
-     *    (foo.fooBar _).returns(_ => "bar")
-     *    foo.foo(1)
-     *    foo.fooBar(true, "bar")
-     *
-     *   (foo.foo _).isAfter(foo.fooBar _) // false
-     *  }}}
-     * */
-    def isAfter(other: Order)(implicit callLog: CallLog): Boolean
-
-    /** Returns string representation of method.
-     *  Representation currently depends on scala version.
-     * */
-    def asString: String
-  }
-
   class Internal[A, R](
     override val asString: String,
     callLog: Option[CallLog],
     io: Option[StubIO]
-  ) extends StubbedMethod[A, R]
-      with StubbedMethod0[R] {
+  ) extends StubbedMethod[A, R] {
 
     override def toString = asString
 
@@ -297,21 +249,18 @@ object StubbedMethod {
     override def returnsWith(value: => R): Unit =
       resultRef.set(Some(_ => value))
 
-    override def returns(f: => R): Unit =
-      returnsWith(f)
-
     override def times: Int =
       callsRef.get().length
 
     override def calls: List[A] =
       callsRef.get().reverse
 
-    override def isBefore(other: Order)(implicit callLog: CallLog): Boolean = {
+    override def isBefore(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean = {
       val actual = callLog.internal.calledMethods
       actual.indexOf(other.asString, actual.indexOf(asString)) != -1
     }
 
-    override def isAfter(other: Order)(implicit callLog: CallLog): Boolean = {
+    override def isAfter(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean = {
       val actual = callLog.internal.calledMethods
       actual.indexOf(asString, actual.indexOf(other.asString)) != -1
     }

--- a/core/shared/src/test/scala-2/newapi/StubbedMethodSpec.scala
+++ b/core/shared/src/test/scala-2/newapi/StubbedMethodSpec.scala
@@ -1,6 +1,6 @@
 package newapi
 
-import org.scalamock.stubs.{CallLog, Stubs, StubbedMethod, StubbedMethod0}
+import org.scalamock.stubs.{CallLog, Stubs, StubbedMethod}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/core/shared/src/test/scala-3/newapi/CallLogSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/CallLogSpec.scala
@@ -3,7 +3,6 @@ package newapi
 import org.scalamock.stubs.{CallLog, Stubs}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalamock.stubs.StubbedMethod0
 
 class CallLogSpec extends AnyFunSpec with Matchers with Stubs {
   trait FirstTrait {

--- a/core/shared/src/test/scala-3/newapi/StubbedMethodSpec.scala
+++ b/core/shared/src/test/scala-3/newapi/StubbedMethodSpec.scala
@@ -1,6 +1,6 @@
 package newapi
 
-import org.scalamock.stubs.{CallLog, Stubs, StubbedMethod, StubbedMethod0}
+import org.scalamock.stubs.{CallLog, Stubs, StubbedMethod}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/zio/shared/src/main/scala-2/org/scalamock/stubs/ZIOStubs.scala
+++ b/zio/shared/src/main/scala-2/org/scalamock/stubs/ZIOStubs.scala
@@ -17,10 +17,10 @@ trait ZIOStubs extends StubsBase {
 
   final implicit val stubIO: ZIOStubIO = new ZIOStubIO()
 
-  implicit def stubbed[R](f: => R)(implicit ev: R <:< IO[Any, Any]): StubbedZIOMethod0[R] =
+  implicit def stubbed[R](f: => R)(implicit ev: R <:< IO[Any, Any]): StubbedZIOMethod[Unit, R] =
     macro ZIOStubMakerImpl.toStubbedMethod00[R]
 
-  implicit def stubbed[R](f: () => R): StubbedZIOMethod0[R] =
+  implicit def stubbed[R](f: () => R): StubbedZIOMethod[Unit, R] =
     macro ZIOStubMakerImpl.toStubbedMethod0[R]
 
   implicit def stubbed[T1, R](f: T1 => R): StubbedZIOMethod[T1, R] =

--- a/zio/shared/src/main/scala-2/org/scalamock/stubs/internal/ZIOStubMakerImpl.scala
+++ b/zio/shared/src/main/scala-2/org/scalamock/stubs/internal/ZIOStubMakerImpl.scala
@@ -1,20 +1,20 @@
 package org.scalamock.stubs.internal
 
-import org.scalamock.stubs.{StubbedZIOMethod0, StubbedZIOMethod, StubbedMethod, StubbedMethod0}
+import org.scalamock.stubs.{StubbedZIOMethod, StubbedMethod}
 import org.scalamock.util.MacroAdapter.Context
 
 private[scalamock]
 object ZIOStubMakerImpl {
-  def toStubbedMethod00[R: c.WeakTypeTag](c: Context)(f: c.Expr[R])(ev: c.Expr[Any]): c.Expr[StubbedZIOMethod0[R]] = {
+  def toStubbedMethod00[R: c.WeakTypeTag](c: Context)(f: c.Expr[R])(ev: c.Expr[Any]): c.Expr[StubbedZIOMethod[Unit, R]] = {
     import c.universe._
-    val sm = StubbedMethodFinder.find[StubbedMethod0[R]](c)(f, List(c.weakTypeOf[Unit]))
-    c.Expr[StubbedZIOMethod0[R]](q"new _root_.org.scalamock.stubs.StubbedZIOMethod0($sm)")
+    val sm = StubbedMethodFinder.find[StubbedMethod[Unit, R]](c)(f, List(c.weakTypeOf[Unit]))
+    c.Expr[StubbedZIOMethod[Unit, R]](q"new _root_.org.scalamock.stubs.StubbedZIOMethod($sm)")
   }
 
-  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedZIOMethod0[R]] = {
+  def toStubbedMethod0[R: c.WeakTypeTag](c: Context)(f: c.Expr[R]): c.Expr[StubbedZIOMethod[Unit, R]] = {
     import c.universe._
-    val sm = StubbedMethodFinder.find[StubbedMethod0[R]](c)(f, List(c.weakTypeOf[Unit]))
-    c.Expr[StubbedZIOMethod0[R]](q"new _root_.org.scalamock.stubs.StubbedZIOMethod0($sm)")
+    val sm = StubbedMethodFinder.find[StubbedMethod[Unit, R]](c)(f, List(c.weakTypeOf[Unit]))
+    c.Expr[StubbedZIOMethod[Unit, R]](q"new _root_.org.scalamock.stubs.StubbedZIOMethod($sm)")
   }
 
   def toStubbedMethod1[T1: c.WeakTypeTag, R: c.WeakTypeTag](c: Context)(f: c.Expr[T1 => R]): c.Expr[StubbedZIOMethod[T1, R]] = {

--- a/zio/shared/src/main/scala-3/org/scalamock/stubs/ZIOStubs.scala
+++ b/zio/shared/src/main/scala-3/org/scalamock/stubs/ZIOStubs.scala
@@ -1,6 +1,6 @@
 package org.scalamock.stubs
 
-import org.scalamock.stubs.{StubbedZIOMethod, StubbedZIOMethod0}
+import org.scalamock.stubs.StubbedZIOMethod
 
 import scala.language.implicitConversions
 import zio.*
@@ -18,14 +18,14 @@ trait ZIOStubs extends StubsBase {
   }
   final given ZIOStubIO = ZIOStubIO()
 
-  implicit inline def stubbed[E, A](inline f: => IO[E, A]): StubbedZIOMethod0[IO[E, A]] =
-    StubbedZIOMethod0[IO[E, A]](stubbed00Impl[IO[E, A]](f))
+  implicit inline def stubbed[E, A](inline f: => IO[E, A]): StubbedZIOMethod[Unit, IO[E, A]] =
+    StubbedZIOMethod[Unit, IO[E, A]](stubbed00Impl[IO[E, A]](f))
 
-  implicit inline def stubbed[R](inline f: => Future[R]): StubbedMethod0[Future[R]] =
-    StubbedZIOMethod0[Future[R]](stubbed00Impl[Future[R]](f))
+  implicit inline def stubbed[R](inline f: => Future[R]): StubbedZIOMethod[Unit, Future[R]] =
+    StubbedZIOMethod[Unit, Future[R]](stubbed00Impl[Future[R]](f))
 
-  implicit inline def stubbed[T1, R](inline f: () => R)(using R =:= R): StubbedZIOMethod0[R] =
-    StubbedZIOMethod0[R](stubbed0Impl[R](f))
+  implicit inline def stubbed[T1, R](inline f: () => R)(using R =:= R): StubbedZIOMethod[Unit, R] =
+    StubbedZIOMethod[Unit, R](stubbed0Impl[R](f))
 
   implicit inline def stubbed[T1, R](inline f: T1 => R)(using (T1, R) =:= (T1, R)): StubbedZIOMethod[T1, R] =
     StubbedZIOMethod[T1, R](stubbed1Impl[T1, R](f))

--- a/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
+++ b/zio/shared/src/main/scala/org/scalamock/stubs/StubbedZIOMethod.scala
@@ -3,159 +3,12 @@ package org.scalamock.stubs
 import zio._
 
 /**
- * Representation of stubbed method without arguments.
- *
- * [[ZIOStubs]] interface provides implicit conversion from selected method to StubbedMethodZIO0.
- * {{{
- *   trait Foo:
- *     def foo00(): String
- *     def fooIO: IO[String, Int]
- *
- *   val foo = stub[Foo]
- * }}}
- *
- * The default way of getting stub for such method - convert it to a function () => R.
- *
- * Exclusively for ZIO - you can omit converting it to function
- *
- * {{{
- *   val foo00Stubbed: StubbedMethod0[String] = () => foo.foo00()
- *   val fooIOStubbed: StubbedMethod0[IO[String, Int]] = foo.fooIO
- * }}}
- * */
-class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R] {
-  /** Allows to set result for method without arguments. Returns ZIO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).returnsZIO("result")
-   *      _ <- foo.fooIO.returnsZIO(ZIO.succeed(1))
-   *    } yield ()
-   * }}}
-   * */
-  @deprecated(
-    "Use `returnsZIOWith`, `succeedsWith`, `failsWith`, `diesWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
-  )
-  def returnsZIO(f: => R): UIO[Unit] = ZIO.succeed(returns(f))
-
-  /** Allows to set result for method without arguments. Returns ZIO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).returnsZIOWith("result")
-   *      _ <- foo.fooIO.returnsZIOWith(ZIO.succeed(1))
-   *    } yield ()
-   * }}}
-   * */
-  def returnsZIOWith(value: => R): UIO[Unit] = returnsZIO(value)
-
-  /** Allows to set success for method without arguments. Returns ZIO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).succeedsWith("result")
-   *      _ <- foo.fooIO.succeedsWith(1)
-   *    } yield ()
-   * }}}
-   * */
-  def succeedsWith[RR](f: => RR)(implicit ev: IO[Nothing, RR] <:< R): UIO[Unit] =
-    returnsZIOWith(ev(ZIO.succeed(f)))
-
-  /** Allows set fail result for method without arguments. Returns ZIO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).failsWith("result")
-   *      _ <- foo.fooIO.failsWith(1)
-   *    } yield ()
-   * }}}
-   * */
-  def failsWith[RR](f: => RR)(implicit ev: IO[RR, Nothing] <:< R): UIO[Unit] =
-    returnsZIOWith(ev(ZIO.fail(f)))
-
-  /** Allows set die result for method without arguments. Returns ZIO.
-   *
-   * {{{
-   *    for {
-   *      _ <- (() => foo.foo00()).diesWith(new Exception("foo"))
-   *      _ <- foo.fooIO.diesWith(new Exception("bar"))
-   *    } yield ()
-   * }}}
-   * */
-  def diesWith(f: => Throwable)(implicit ev: UIO[Nothing] <:< R): UIO[Unit] =
-    returnsZIOWith(ev(Exit.die(f)))
-
-  /** Allows to get number of times method was executed. Returns ZIO
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.returnsZIO(ZIO.succeed(1))
-   *      _ <- foo.fooIO.repeatN(10)
-   *      fooIOTimes <- foo.fooIO.timesZIO
-   *    } yield fooIOTimes == 11 // true
-   * }}}
-   * */
-  def timesZIO: UIO[Int] = ZIO.succeed(times)
-
-  /** Allows to set result for method without arguments.
-   *
-   * {{{
-   *   (() => foo.foo00()).returns("result")
-   *   foo.fooIO.returns(ZIO.succeed(1))
-   * }}}
-   * */
-  @deprecated(
-    "Use `returnsWith` instead. Will be deleted in first release after 01.07.2025. This is needed to replace StubbedMethod0[R] with StubbedMethod[Unit, R]"
-  )
-  def returns(f: => R): Unit = delegate.returns(f)
-
-  /** Allows to set result for method without arguments.
-   *
-   * {{{
-   *   (() => foo.foo00()).returnsWith("result")
-   *   foo.fooIO.returnsWith(ZIO.succeed(1))
-   * }}}
-   * */
-  def returnsWith(value: => R) = delegate.returnsWith(value)
-
-  /** Allows to get number of times method was executed.
-   *
-   * {{{
-   *    for {
-   *      _ <- foo.fooIO.returnsZIO(ZIO.succeed(1))
-   *      _ <- foo.fooIO.repeatN(10)
-   *    } yield foo.fooIO.times == 11 // true
-   * }}}
-   * */
-  def times: Int = delegate.times
-
-  /**
-   * Returns true if this method was called before other method.
-   */
-  def isBefore(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
-    delegate.isBefore(other)
-
-  /**
-   * Returns true if this method was called after other method.
-   */
-  def isAfter(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
-    delegate.isAfter(other)
-
-  /**
-   *  Returns string representation of method.
-   *  Representation currently depends on scala version.
-   * */
-  def asString: String = delegate.asString
-
-  override def toString: String = asString
-}
-
-/**
- * Representation of stubbed method with arguments.
+ * Representation of stubbed method.
  *
  * [[ZIOStubs]] interface provides implicit conversion from selected method to StubbedMethodZIO.
  * {{{
  *   trait Foo:
+ *     def foo0: UIO[Int]
  *     def foo(x: Int): UIO[String]
  *     def bar(x: Int, y: String): IO[String, Int]
  *
@@ -164,12 +17,14 @@ class StubbedZIOMethod0[R](delegate: StubbedMethod0[R]) extends StubbedMethod0[R
  *
  * Scala 3
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, UIO[Int]] = foo.foo0
  *   val fooStubbed: StubbedMethod[Int, UIO[String]] = foo.foo
  *   val barStubbed: StubbedMethod[(Int, String), IO[String, Int]] = foo.bar
  * }}}
  *
  * Scala 2
  * {{{
+ *   val foo0Stubbed: StubbedMethod[Unit, UIO[Int]] = foo.foo0 _
  *   val fooStubbed: StubbedMethod[Int, UIO[String]] = foo.foo _
  *   val barStubbed: StubbedMethod[(Int, String), IO[String, Int]] = foo.bar _
  * }}}
@@ -404,13 +259,13 @@ class StubbedZIOMethod[A, R](delegate: StubbedMethod[A, R]) extends StubbedMetho
   /**
    * Returns true if this method was called before other method.
    */
-  def isBefore(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
+  def isBefore(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean =
     delegate.isBefore(other)
 
   /**
    * Returns true if this method was called after other method.
    */
-  def isAfter(other: StubbedMethod.Order)(implicit callLog: CallLog): Boolean =
+  def isAfter(other: StubbedMethod[_, _])(implicit callLog: CallLog): Boolean =
     delegate.isAfter(other)
 
   /**

--- a/zio/shared/src/test/scala-3/newapi/ZIOSpec.scala
+++ b/zio/shared/src/test/scala-3/newapi/ZIOSpec.scala
@@ -55,7 +55,7 @@ object ZIOSpec extends ZIOSpecDefault, ZIOStubs:
         for
           _ <- foo.zeroArgsTask.returnsZIOWith(ZIO.none)
           _ <- foo.zeroArgsTask.repeatN(10)
-        yield assertTrue(foo.zeroArgsTask.times == 11),
+        yield assertTrue(foo.zeroArgsTask.calls.size == 11),
       test("two args and cleanup"):
         for
           _ <- foo.twoArgsIOFail.returnsZIO(_ => ZIO.fail(2))
@@ -64,7 +64,7 @@ object ZIOSpec extends ZIOSpecDefault, ZIOStubs:
           times2 <- foo.zeroArgsTask.timesZIO
           result = assertTrue(
             foo.twoArgsIOFail.calls == List((1, "")),
-            foo.zeroArgsTask.times == 0
+            foo.zeroArgsTask.calls.isEmpty
           )
         yield result,
       test("one arg"):


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Purpose
`StubbedMethod0[R]` can be just `StubbedMethod[Unit, R]`. This will generalize interface and make it simpler.
This should be merged and published not earlier than 01.07.2025 with upped minor version, since change is not source compatible
