### PR TITLE
fix by-name constructor arg mocking

### DIFF
--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -68,12 +68,11 @@ private[scalamock] class Utils(using val quotes: Quotes):
 
         con.appliedToArgss(
           constructorFields
-            .map(_.map { sym => typeNames(sym.name).asType })
-            .map(_.map {
-              case '[t] => '{ ${ Expr.summon[Defaultable[t]].get }.default }.asTerm
-              // handles by-name constructor args
-              case _ => '{ null }.asTerm
-            })
+            .map(_.map { sym => typeNames(sym.name) match {
+              case n: ByNameType => n.widenByName.asType
+              case n => n.asType
+            } })
+            .map(_.map { case '[t] => '{ ${ Expr.summon[Defaultable[t]].get }.default }.asTerm })
         )
     end asParent
 

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -60,15 +60,13 @@ private[scalamock] class Utils(using val quotes: Quotes):
           @tailrec
           def collectTypes(tpe: TypeRepr, acc: Map[String, TypeRepr]): Map[String, TypeRepr] =
             tpe match
-              case MethodType(names, types, res) =>
-                val typesByValue = types.map {
-                  case n: ByNameType => n.widenByName
-                  case n => n
-                }
-                collectTypes(res, acc ++ names.zip(typesByValue))
+              case MethodType(names, types, res) => collectTypes(res, acc ++ names.zip(types))
               case tpe => acc
 
-          collectTypes(con.tpe.widenTermRefByName, Map.empty)
+          collectTypes(con.tpe.widenTermRefByName, Map.empty).view.mapValues {
+            case n: ByNameType => n.widenByName
+            case n => n
+          }.toMap
         }
 
         con.appliedToArgss(

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -69,7 +69,11 @@ private[scalamock] class Utils(using val quotes: Quotes):
         con.appliedToArgss(
           constructorFields
             .map(_.map { sym => typeNames(sym.name).asType })
-            .map(_.map { case '[t] => '{ ${Expr.summon[Defaultable[t]].get}.default }.asTerm })
+            .map(_.map {
+              case '[t] => '{ ${ Expr.summon[Defaultable[t]].get }.default }.asTerm
+              // handles by-name constructor args
+              case _ => '{ null }.asTerm
+            })
         )
     end asParent
 

--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -60,7 +60,12 @@ private[scalamock] class Utils(using val quotes: Quotes):
           @tailrec
           def collectTypes(tpe: TypeRepr, acc: Map[String, TypeRepr]): Map[String, TypeRepr] =
             tpe match
-              case MethodType(names, types, res) => collectTypes(res, acc ++ names.zip(types))
+              case MethodType(names, types, res) =>
+                val typesByValue = types.map {
+                  case n: ByNameType => n.widenByName
+                  case n => n
+                }
+                collectTypes(res, acc ++ names.zip(typesByValue))
               case tpe => acc
 
           collectTypes(con.tpe.widenTermRefByName, Map.empty)
@@ -68,11 +73,8 @@ private[scalamock] class Utils(using val quotes: Quotes):
 
         con.appliedToArgss(
           constructorFields
-            .map(_.map { sym => typeNames(sym.name) match {
-              case n: ByNameType => n.widenByName.asType
-              case n => n.asType
-            } })
-            .map(_.map { case '[t] => '{ ${ Expr.summon[Defaultable[t]].get }.default }.asTerm })
+            .map(_.map { sym => typeNames(sym.name).asType })
+            .map(_.map { case '[t] => '{ ${Expr.summon[Defaultable[t]].get}.default }.asTerm })
         )
     end asParent
 

--- a/core/shared/src/test/scala-3/com/paulbutcher/test/MockTestScala3.scala
+++ b/core/shared/src/test/scala-3/com/paulbutcher/test/MockTestScala3.scala
@@ -105,5 +105,10 @@ class MockTestScala3 extends AnyFreeSpec with MockFactory with Matchers {
       m1.thisTypeMethod(1) shouldBe m1
     }
 
+    "mock by-name arguments" in {
+      class ByName(t: => String)
+      "mock[ByName]" should compile
+    }
+
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [x] I have added copyright headers to new files
* [x] I have added tests for any changed functionality

## Fixes

Fixes mocking classes with by-name constructor args in scala 3

New test would've otherwise failed with:
```
[info] - mock by-name arguments *** FAILED ***
[info]   Expected no compiler error, but got the following type error: "Exception occurred while executing macro expansion.
[info]   scala.MatchError: Type.of[...] (of class scala.quoted.runtime.impl.TypeImpl)
[info]   	at org.scalamock.clazz.Utils.asParent$1$$anonfun$3$$anonfun$1(Utils.scala:72)
```
