### PR TITLE
fix: no more lookup failure when a method defines an hkt in its signature

### DIFF
--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -46,9 +46,76 @@ private[scalamock] class Utils(using val quotes: Quotes):
           case poly: PolyType => poly.paramTypes.lengthCompare(appliedTypes) == 0
           case _ => appliedTypes.isEmpty
 
+      def matchTypeConstructor(actual: TypeRepr, expected: TypeRepr): Boolean = {        
+        // Extract type constructor symbols
+        val actualSym = actual.typeSymbol
+        val expectedSym = expected.typeSymbol
+        // Check if they're the same type constructor or if actual is a subtype
+        actualSym == expectedSym || {
+          // Check if actual's type constructor conforms to expected
+          actual.baseType(expectedSym) != NoPrefix
+        }
+      }
+
+      def matchTypes(actualTypes: List[TypeRepr], expectedTypes: List[TypeRepr]): Boolean = {        
+        if (actualTypes.length != expectedTypes.length) return false
+        actualTypes.zip(expectedTypes).forall(matchType)
+      }
+      
+      def matchType(actual: TypeRepr, expected: TypeRepr): Boolean =
+        if (actual <:< expected) return true
+
+        expected match {
+          // Handle type parameters like F[_]
+          case AppliedType(expectedTyCon, expectedArgs) =>
+            actual match {
+              case AppliedType(actualTyCon, actualArgs) =>
+                // Check if type constructors match
+                val tyConMatch = actualTyCon.typeSymbol == expectedTyCon.typeSymbol ||
+                              actualTyCon <:< expectedTyCon ||
+                              matchTypeConstructor(actualTyCon, expectedTyCon)
+                
+                if (!tyConMatch) return false
+                
+                // Check if args match (handling wildcards)
+                if (expectedArgs.length != actualArgs.length) return false
+                
+                expectedArgs.zip(actualArgs).forall { case (expArg, actArg) =>
+                  expArg match {
+                    // Wildcard bounds like _ >: Nothing <: Any
+                    case TypeBounds(lo, hi) =>
+                      // Any concrete type fits within Nothing <: _ <: Any
+                      actArg match {
+                        case TypeBounds(actLo, actHi) =>
+                          // Both are bounds, check compatibility
+                          lo <:< actLo && actHi <:< hi
+                        case _ =>
+                          // Concrete type must fit within bounds
+                          lo <:< actArg && actArg <:< hi
+                      }
+                    case _ =>
+                      // Non-wildcard argument must match
+                      matchType(actArg, expArg)
+                  }
+                }
+                
+              case _ => false
+            }
+          
+          // Handle type parameters themselves (like F, Container, etc.)
+          case param: TypeRepr if param.typeSymbol.isTypeParam =>
+            // Type parameter without application - check if actual has same shape
+            actual match {
+              case AppliedType(_, _) => true // Any applied type matches F[_]
+              case _ => actual.typeSymbol.isTypeParam
+            }
+          
+          case _ => false
+        }
+
       def typesMatch(method: MockableDefinition, paramTypes: List[TypeRepr]): Boolean =
         paramTypes.lengthCompare(method.parameterTypes) == 0 &&
-          paramTypes.zip(method.parameterTypes).forall(_ <:< _)
+          paramTypes.zip(method.parameterTypes).forall(matchType)
 
       MockableDefinitions(tpe)
         .filter(m => m.symbol.name == name && typesMatch(m, paramTypes) && appliedTypesMatch(m, appliedTypes))

--- a/core/shared/src/test/scala-3/newapi/StubbedHigherKindedMethods.scala
+++ b/core/shared/src/test/scala-3/newapi/StubbedHigherKindedMethods.scala
@@ -1,0 +1,15 @@
+package newapi
+
+import org.scalamock.stubs.{CallLog, Stubs, StubbedMethod}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class StubbedHigherKindedMethods extends AnyFlatSpec with Matchers with Stubs:
+  trait TestTrait:
+    def higherKind[F[_], A](fa: F[A]): Unit
+
+  "StubbedMethod for higher-kind methods" should "set the return value for a higher-kind method" in:
+    val hktStub = stub[TestTrait]
+    hktStub.higherKind[List, Int].returns(_ => ())
+    hktStub.higherKind(List(1, 2, 3))
+    hktStub.higherKind[List, Int].times shouldBe 1


### PR DESCRIPTION
# Pull Request Checklist

* [X] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [X] I have added copyright headers to new files
* [X] I have added tests for any changed functionality

## Fixes

This PR fixes #696

## Purpose

When a method in a trait is defined as follows:

```scala
trait Foo:
  def foo[F[_], V](data: F[V]): Unit
```

trying to stub it:

```scala
val stubbed = stub[Foo]
stubbed.foo[List, Int].returns(_ => ())
```

returns the error: `Method with such signature not found`

This PR fixes such an error.

## Background Context

I extended the algorithm, considering also the conformance to the type signature when the actual parameters are tested against the signature.

## References

Fixes issue #696 
