### PR TITLE
Preserve method order in a Scala 3 macro

### DIFF
--- a/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
+++ b/core/shared/src/main/scala-3/org/scalamock/clazz/Utils.scala
@@ -39,6 +39,8 @@ private[scalamock] class Utils(using val quotes: Quotes):
       }
 
   object MockableDefinitions:
+    private val objectMethods = TypeRepr.of[Object].typeSymbol.methodMembers.toSet
+
     @experimental
     def find(tpe: TypeRepr, name: String, paramTypes: List[TypeRepr], appliedTypes: List[TypeRepr]): MockableDefinition =
       def appliedTypesMatch(method: MockableDefinition, appliedTypes: List[TypeRepr]): Boolean =
@@ -58,9 +60,10 @@ private[scalamock] class Utils(using val quotes: Quotes):
 
 
     def apply(tpe: TypeRepr): List[MockableDefinition] =
-      val methods = (tpe.typeSymbol.methodMembers.toSet -- TypeRepr.of[Object].typeSymbol.methodMembers).toList
+      val methods = tpe.typeSymbol.methodMembers
         .filter(sym =>
-          !sym.flags.is(Flags.Private) &&
+          !objectMethods.contains(sym) &&
+            !sym.flags.is(Flags.Private) &&
             !sym.flags.is(Flags.Final) &&
             !sym.flags.is(Flags.Mutable) &&
             !sym.flags.is(Flags.Artifact) &&


### PR DESCRIPTION
# Pull Request Checklist

* [x] I agree to licence my contributions under the [MIT licence](https://github.com/paulbutcher/ScalaMock/blob/master/LICENCE)
* [ ] I have added copyright headers to new files
* [ ] I have added tests for any changed functionality

## Purpose

Currently, the order of methods returned by `MockableDefinitions.apply` may change between compiler invocations due to the use of `toSet`. This can lead to `java.lang.NoSuchMethodError` errors at runtime when using incremental compilation or when stubs are created in one module and used in another.

This PR preserves the order of values ​​returned from `methodMembers`. The order is determined by [this](https://github.com/scala/scala3/blob/66b14d3302dd6c3c9f456bde4342086930749490/compiler/src/dotty/tools/dotc/core/Types.scala#L1046) method and, according to the comment, should be stable.
